### PR TITLE
Handle disconnect errors when clearing API key

### DIFF
--- a/LANImageUploader/AppData.swift
+++ b/LANImageUploader/AppData.swift
@@ -147,7 +147,13 @@ class AppData: ObservableObject {
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrAccount as String: apiKeyKey
         ]
-        SecItemDelete(deleteQuery as CFDictionary)
+        let status = SecItemDelete(deleteQuery as CFDictionary)
+        if status != errSecSuccess && status != errSecItemNotFound {
+            throw NSError(
+                domain: "KeychainError",
+                code: Int(status),
+                userInfo: [NSLocalizedDescriptionKey: "Failed to delete existing API key"])
+        }
 
         if !apiKey.isEmpty {
             let apiKeyData = apiKey.data(using: .utf8)!
@@ -156,10 +162,11 @@ class AppData: ObservableObject {
                 kSecAttrAccount as String: apiKeyKey,
                 kSecValueData as String: apiKeyData
             ]
-            let status = SecItemAdd(addQuery as CFDictionary, nil)
-            guard status == errSecSuccess else {
+            let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+            guard addStatus == errSecSuccess else {
                 throw NSError(
-                    domain: "KeychainError", code: Int(status),
+                    domain: "KeychainError",
+                    code: Int(addStatus),
                     userInfo: [NSLocalizedDescriptionKey: "Failed to save API key"])
             }
         }

--- a/LANImageUploader/SettingsView.swift
+++ b/LANImageUploader/SettingsView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct SettingsView: View {
     @EnvironmentObject var appData: AppData
     @State private var showDisconnectConfirmation = false
+    @State private var disconnectError: String?
 
     var body: some View {
         Form {
@@ -38,11 +39,29 @@ struct SettingsView: View {
         } message: {
             Text("Are you sure you want to disconnect from the server? You will need to scan the QR code again to reconnect.")
         }
+        .alert("Error", isPresented: Binding(
+            get: { disconnectError != nil },
+            set: { if !$0 { disconnectError = nil } }
+        )) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(disconnectError ?? "Unknown error")
+        }
     }
 
     private func disconnect() {
-        appData.settings.baseURL = ""
-        try? appData.saveAPIKey("")
+        DispatchQueue.global(qos: .userInitiated).async {
+            do {
+                try self.appData.saveAPIKey("")
+                DispatchQueue.main.async {
+                    self.appData.settings.baseURL = ""
+                }
+            } catch {
+                DispatchQueue.main.async {
+                    self.disconnectError = error.localizedDescription
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- surface errors when disconnecting by showing an alert
- stop suppressing errors from `saveAPIKey` to avoid hidden failures
- clear the API key on a background queue to keep the UI responsive
- throw an error when keychain deletion fails so disconnect can surface it

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*
- `xcodebuild test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1491dd8bc83209cc814108a537dad