### PR TITLE
Handle disconnect errors when clearing API key

### DIFF
--- a/LANImageUploader/AppData.swift
+++ b/LANImageUploader/AppData.swift
@@ -37,6 +37,20 @@ enum UploadStatus: Equatable {
     case failure(String)
 }
 
+enum KeychainError: Error, LocalizedError {
+    case deleteFailed(OSStatus)
+    case addFailed(OSStatus)
+
+    var errorDescription: String? {
+        switch self {
+        case .deleteFailed:
+            return "Failed to delete existing API key."
+        case .addFailed:
+            return "Failed to save API key."
+        }
+    }
+}
+
 class AppData: ObservableObject {
     @Published var images: [CapturedImage] = []
     @Published var settings: ServerSettings {
@@ -147,7 +161,10 @@ class AppData: ObservableObject {
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrAccount as String: apiKeyKey
         ]
-        SecItemDelete(deleteQuery as CFDictionary)
+        let status = SecItemDelete(deleteQuery as CFDictionary)
+        if status != errSecSuccess && status != errSecItemNotFound {
+            throw KeychainError.deleteFailed(status)
+        }
 
         if !apiKey.isEmpty {
             let apiKeyData = apiKey.data(using: .utf8)!
@@ -156,11 +173,9 @@ class AppData: ObservableObject {
                 kSecAttrAccount as String: apiKeyKey,
                 kSecValueData as String: apiKeyData
             ]
-            let status = SecItemAdd(addQuery as CFDictionary, nil)
-            guard status == errSecSuccess else {
-                throw NSError(
-                    domain: "KeychainError", code: Int(status),
-                    userInfo: [NSLocalizedDescriptionKey: "Failed to save API key"])
+            let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+            guard addStatus == errSecSuccess else {
+                throw KeychainError.addFailed(addStatus)
             }
         }
     }

--- a/LANImageUploader/SettingsView.swift
+++ b/LANImageUploader/SettingsView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct SettingsView: View {
     @EnvironmentObject var appData: AppData
     @State private var showDisconnectConfirmation = false
+    @State private var disconnectError: Error?
 
     var body: some View {
         Form {
@@ -38,11 +39,28 @@ struct SettingsView: View {
         } message: {
             Text("Are you sure you want to disconnect from the server? You will need to scan the QR code again to reconnect.")
         }
+        .alert("Error", isPresented: Binding(
+            get: { disconnectError != nil },
+            set: { if !$0 { disconnectError = nil } }
+        )) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(disconnectError?.localizedDescription ?? "Unknown error")
+        }
     }
 
     private func disconnect() {
-        appData.settings.baseURL = ""
-        try? appData.saveAPIKey("")
+        let appData = self.appData
+        Task {
+            do {
+                try await Task.detached(priority: .userInitiated) {
+                    try appData.saveAPIKey("")
+                }.value
+                self.appData.settings.baseURL = ""
+            } catch {
+                self.disconnectError = error
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- surface errors when disconnecting by showing an alert
- stop suppressing errors from `saveAPIKey` to avoid hidden failures
- clear the API key on a background queue to keep the UI responsive
- throw an error when keychain deletion fails so disconnect can surface it
- refactor keychain errors into a typed `KeychainError` enum and adopt Swift concurrency for disconnect

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*
- `xcodebuild test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1491dd8bc83209cc814108a537dad