### PR TITLE
🔒 [security fix] Insecure Keychain Storage Configuration

### DIFF
--- a/LANImageUploader/AppData.swift
+++ b/LANImageUploader/AppData.swift
@@ -191,13 +191,21 @@ class AppData: ObservableObject {
 
     func savePassword(_ password: String) throws {
         let passwordData = password.data(using: .utf8)!
-        let query: [String: Any] = [
+
+        let deleteQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: passwordKey,
+        ]
+        SecItemDelete(deleteQuery as CFDictionary)
+
+        let addQuery: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrAccount as String: passwordKey,
             kSecValueData as String: passwordData,
+            kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
         ]
-        SecItemDelete(query as CFDictionary)
-        let status = SecItemAdd(query as CFDictionary, nil)
+
+        let status = SecItemAdd(addQuery as CFDictionary, nil)
         guard status == errSecSuccess else {
             throw NSError(
                 domain: "KeychainError", code: Int(status),


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is the insecure storage configuration of the SMB server password in the iOS Keychain.

⚠️ **Risk:** Previously, the password was stored without an explicit accessibility attribute. This could allow access to the sensitive data when the device is locked or allow it to be synced across devices via iCloud, increasing the attack surface.

🛡️ **Solution:** 
- Modified `AppData.savePassword(_:)` to include `kSecAttrAccessible: kSecAttrAccessibleWhenUnlockedThisDeviceOnly`. This ensures the password is only accessible when the device is unlocked and prevents it from being synced to other devices or included in unencrypted backups.
- Refactored the "delete-before-add" logic to use a minimal query (class and account) for `SecItemDelete`, preventing unnecessary exposure of sensitive data in the deletion query.

**Verification:**
Manual verification was performed using `grep` and code inspection, as the `xcodebuild` and `swift` toolchains are unavailable in the current environment.
- Confirmed `kSecAttrAccessibleWhenUnlockedThisDeviceOnly` is correctly applied in `LANImageUploader/AppData.swift`.
- Verified that `SecItemDelete` uses a restricted query.
- Verified that `SecItemAdd` includes all necessary attributes for secure storage.

---
*PR created automatically by Jules for task [13492473747919969368](https://jules.google.com/task/13492473747919969368) started by @janhcla*