### PR TITLE
🧪 [testing improvement] Add tests for AppData getArchivedDates and getImagesForDate

### DIFF
--- a/LANImageUploaderTests/LANImageUploaderTests.swift
+++ b/LANImageUploaderTests/LANImageUploaderTests.swift
@@ -21,7 +21,7 @@ struct LANImageUploaderTests {
             fileService: mockFile,
             uploadService: mockUpload,
             discoveryService: mockDiscovery,
-            hapticService: HapticFeedbackService.shared
+            hapticService: MockHapticFeedbackService()
         )
         
         #expect(appData.images.isEmpty)
@@ -36,7 +36,7 @@ struct LANImageUploaderTests {
             fileService: mockFile,
             uploadService: MockImageUploadService(),
             discoveryService: MockNetworkDiscovery(),
-            hapticService: HapticFeedbackService.shared
+            hapticService: MockHapticFeedbackService()
         )
         
         await appData.saveImagesToDatedFolder()
@@ -53,7 +53,7 @@ struct LANImageUploaderTests {
             fileService: mockFile,
             uploadService: MockImageUploadService(),
             discoveryService: MockNetworkDiscovery(),
-            hapticService: HapticFeedbackService.shared
+            hapticService: MockHapticFeedbackService()
         )
         
         await appData.saveImagesToDatedFolder()
@@ -71,7 +71,7 @@ struct LANImageUploaderTests {
             fileService: mockFile,
             uploadService: MockImageUploadService(),
             discoveryService: MockNetworkDiscovery(),
-            hapticService: HapticFeedbackService.shared
+            hapticService: MockHapticFeedbackService()
         )
 
         let result = await appData.getArchivedDates()
@@ -89,7 +89,7 @@ struct LANImageUploaderTests {
             fileService: mockFile,
             uploadService: MockImageUploadService(),
             discoveryService: MockNetworkDiscovery(),
-            hapticService: HapticFeedbackService.shared
+            hapticService: MockHapticFeedbackService()
         )
 
         let result = await appData.getImagesForDate(testDate)

--- a/LANImageUploaderTests/LANImageUploaderTests.swift
+++ b/LANImageUploaderTests/LANImageUploaderTests.swift
@@ -62,6 +62,41 @@ struct LANImageUploaderTests {
         #expect(appData.scanStatus.contains("Disk Full"))
     }
 
+    @Test @MainActor func appDataGetArchivedDates() async throws {
+        let mockFile = MockFileService()
+        let expectedDates = ["2024-01-01", "2024-01-02"]
+        mockFile.getArchivedDatesResult = expectedDates
+
+        let appData = AppData(
+            fileService: mockFile,
+            uploadService: MockImageUploadService(),
+            discoveryService: MockNetworkDiscovery(),
+            hapticService: HapticFeedbackService.shared
+        )
+
+        let result = await appData.getArchivedDates()
+
+        #expect(result == expectedDates)
+    }
+
+    @Test @MainActor func appDataGetImagesForDate() async throws {
+        let mockFile = MockFileService()
+        let testDate = "2024-01-01"
+        let expectedURLs = [URL(fileURLWithPath: "/tmp/1.jpg"), URL(fileURLWithPath: "/tmp/2.jpg")]
+        mockFile.getImagesForDateResult = expectedURLs
+
+        let appData = AppData(
+            fileService: mockFile,
+            uploadService: MockImageUploadService(),
+            discoveryService: MockNetworkDiscovery(),
+            hapticService: HapticFeedbackService.shared
+        )
+
+        let result = await appData.getImagesForDate(testDate)
+
+        #expect(result == expectedURLs)
+    }
+
     @Test func connectionStatusEnumExists() async throws {
         let status = ConnectionStatus.disconnected
         #expect(status == .disconnected)

--- a/LANImageUploaderTests/Mocks/MockHapticFeedbackService.swift
+++ b/LANImageUploaderTests/Mocks/MockHapticFeedbackService.swift
@@ -1,0 +1,34 @@
+//
+//  MockHapticFeedbackService.swift
+//  LANImageUploaderTests
+//
+
+import Foundation
+import UIKit
+@testable import LANImageUploader
+
+final class MockHapticFeedbackService: HapticFeedbackServiceProtocol, @unchecked Sendable {
+    var playSelectionCalled = false
+    func playSelection() {
+        playSelectionCalled = true
+    }
+
+    var playImpactCalled = false
+    var lastImpactStyle: UIImpactFeedbackGenerator.FeedbackStyle?
+    func playImpact(style: UIImpactFeedbackGenerator.FeedbackStyle) {
+        playImpactCalled = true
+        lastImpactStyle = style
+    }
+
+    var playNotificationCalled = false
+    var lastNotificationType: UINotificationFeedbackGenerator.FeedbackType?
+    func playNotification(type: UINotificationFeedbackGenerator.FeedbackType) {
+        playNotificationCalled = true
+        lastNotificationType = type
+    }
+
+    var playLiquidBounceCalled = false
+    func playLiquidBounce() {
+        playLiquidBounceCalled = true
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: Missing tests for `AppData.getArchivedDates()` and `AppData.getImagesForDate(_:)`.
📊 **Coverage:** What scenarios are now tested:
- `appDataGetArchivedDates`: Verifies that `AppData` correctly returns the list of archived dates from `FileService`.
- `appDataGetImagesForDate`: Verifies that `AppData` correctly returns the list of image URLs for a specific date from `FileService`.
✨ **Result:** The improvement in test coverage: Improved reliability of the archival retrieval logic in `AppData`.

---
*PR created automatically by Jules for task [5290688156179428820](https://jules.google.com/task/5290688156179428820) started by @janhcla*