### PR TITLE
Refactor: Rename pathComponents to targetComponents

### DIFF
--- a/LANImageUploader/NetworkDiscovery.swift
+++ b/LANImageUploader/NetworkDiscovery.swift
@@ -802,10 +802,9 @@ extension NetworkDiscovery {
             }
         }
 
-        // FIX: rename to pathComponents to avoid redeclaration with URLComponents
-        let pathComponents = normalizedTarget.split(separator: "/", omittingEmptySubsequences: true)
-        if let shareGuess = pathComponents.first {
-            let remainder = pathComponents.dropFirst().joined(separator: "/")
+        let targetComponents = normalizedTarget.split(separator: "/", omittingEmptySubsequences: true)
+        if let shareGuess = targetComponents.first {
+            let remainder = targetComponents.dropFirst().joined(separator: "/")
             addCandidate(share: String(shareGuess), directory: remainder.isEmpty ? nil : remainder)
         }
         addCandidate(share: normalizedTarget, directory: nil)


### PR DESCRIPTION
Renames the `pathComponents` local variable to `targetComponents` in `LANImageUploader/NetworkDiscovery.swift` to prevent redeclaration issues and resolves the inline FIX comment.

Note: Tests could not be run as `xcodebuild` and `swift` are unavailable in the environment. Manual verification of changes was performed using `cat` and `grep` to ensure correctness.

---
*PR created automatically by Jules for task [3235268387672792597](https://jules.google.com/task/3235268387672792597) started by @janhcla*