### PR TITLE
🔒 Fix Path Traversal in SMB Upload Destination

### DIFF
--- a/LANImageUploader/ImageUploadService.swift
+++ b/LANImageUploader/ImageUploadService.swift
@@ -117,14 +117,15 @@ final class ImageUploadService: ImageUploadServiceProtocol {
             try await client.connectShare(name: settings.shareName)
             
             let targetDir = settings.targetDirectory?.trimmingCharacters(in: .init(charactersIn: "/\\")) ?? ""
-            let destinationPath = targetDir.isEmpty ? "\(image.name).jpg" : "\(targetDir)/\(image.name).jpg"
+            let sanitizedName = image.name.replacingOccurrences(of: "/", with: "_").replacingOccurrences(of: "\\", with: "_")
+            let destinationPath = targetDir.isEmpty ? "\(sanitizedName).jpg" : "\(targetDir)/\(sanitizedName).jpg"
 
             // Check for duplicates if not overwriting
             if !overwrite {
                 let parentPath = targetDir.isEmpty ? "" : targetDir
                 do {
                     let contents = try await client.contentsOfDirectory(atPath: parentPath)
-                    if contents.contains(where: { $0.name == "\(image.name).jpg" }) {
+                    if contents.contains(where: { $0.name == "\(sanitizedName).jpg" }) {
                         try? await client.disconnectShare()
                         throw UploadError.fileAlreadyExists(image.name)
                     }

--- a/commit_message.txt
+++ b/commit_message.txt
@@ -1,0 +1,5 @@
+🔒 Fix Path Traversal in SMB Upload Destination
+
+🎯 **What:** The user input `image.name` was being used directly to construct the `destinationPath` without sanitization.
+⚠️ **Risk:** An attacker or malicious input could use characters like `../` to traverse the directory structure and write files outside the intended target directory on the SMB server.
+🛡️ **Solution:** Implemented a sanitization step to replace any `/` or `\` characters in `image.name` with `_` before constructing `destinationPath`. This ensures the file is safely stored in the expected location.


### PR DESCRIPTION
🎯 **What:** The user input `image.name` was being used directly to construct the `destinationPath` without sanitization.
⚠️ **Risk:** An attacker or malicious input could use characters like `../` to traverse the directory structure and write files outside the intended target directory on the SMB server.
🛡️ **Solution:** Implemented a sanitization step to replace any `/` or `\` characters in `image.name` with `_` before constructing `destinationPath`. This ensures the file is safely stored in the expected location.

---
*PR created automatically by Jules for task [15119550882822699081](https://jules.google.com/task/15119550882822699081) started by @janhcla*