### PR TITLE
⚡ Comprehensive archive performance optimization with TaskGroup

### DIFF
--- a/LANImageUploader/ArchiveView.swift
+++ b/LANImageUploader/ArchiveView.swift
@@ -253,43 +253,68 @@ struct ArchiveView: View {
 
     private func restoreSelectedArchives() async {
         appData.hapticService.playLiquidBounce()
-        var successCount = 0
-        var failureCount = 0
+        let datesToRestore = Array(selectedDates)
+        let docs = await appData.fileService.documentsDirectory
+        let imagesFolderURL = docs.appendingPathComponent("images")
 
-        for date in selectedDates {
-            let images = await appData.getImagesForDate(date)
-            let docs = await appData.fileService.documentsDirectory
-            let imagesFolderURL = docs.appendingPathComponent("images")
+        try? await appData.fileService.createDirectory(at: imagesFolderURL)
 
-            do {
-                try await appData.fileService.createDirectory(at: imagesFolderURL)
+        struct RestorationResult {
+            let successCount: Int
+            let failureCount: Int
+            let restoredImages: [CapturedImage]
+        }
 
-                for imageURL in images {
-                    let destinationURL = imagesFolderURL.appendingPathComponent(
-                        imageURL.lastPathComponent)
+        let (totalSuccess, totalFailure, allRestored) = await withTaskGroup(of: RestorationResult.self) { group in
+            for date in datesToRestore {
+                group.addTask {
+                    let images = await self.appData.getImagesForDate(date)
+                    var localSuccess = 0
+                    var localFailure = 0
+                    var localRestored: [CapturedImage] = []
 
-                    if !appData.images.contains(where: { $0.fileURL == destinationURL }) {
-                        try? await appData.fileService.removeItem(at: destinationURL)
-                        try await appData.fileService.copyItem(at: imageURL, to: destinationURL)
-                        let capturedImage = CapturedImage(
-                            name: imageURL.deletingPathExtension().lastPathComponent,
-                            fileURL: destinationURL)
-                        await MainActor.run {
-                            appData.images.append(capturedImage)
+                    for imageURL in images {
+                        let destinationURL = imagesFolderURL.appendingPathComponent(imageURL.lastPathComponent)
+
+                        let alreadyInGallery = await MainActor.run {
+                            self.appData.images.contains(where: { $0.fileURL == destinationURL })
                         }
-                        successCount += 1
-                    } else {
-                        failureCount += 1
+
+                        if !alreadyInGallery {
+                            do {
+                                try? await self.appData.fileService.removeItem(at: destinationURL)
+                                try await self.appData.fileService.copyItem(at: imageURL, to: destinationURL)
+                                let capturedImage = CapturedImage(
+                                    name: imageURL.deletingPathExtension().lastPathComponent,
+                                    fileURL: destinationURL)
+                                localRestored.append(capturedImage)
+                                localSuccess += 1
+                            } catch {
+                                print("Failed to restore image \(imageURL.lastPathComponent): \(error)")
+                                localFailure += 1
+                            }
+                        } else {
+                            localFailure += 1
+                        }
                     }
+                    return RestorationResult(successCount: localSuccess, failureCount: localFailure, restoredImages: localRestored)
                 }
-            } catch {
-                print("Failed to restore archive \(date): \(error)")
-                failureCount += 1
             }
+
+            var success = 0
+            var failure = 0
+            var restored: [CapturedImage] = []
+            for await res in group {
+                success += res.successCount
+                failure += res.failureCount
+                restored.append(contentsOf: res.restoredImages)
+            }
+            return (success, failure, restored)
         }
 
         await MainActor.run {
-            restoreMessage = "Restored \(successCount) images" + (failureCount > 0 ? " (\(failureCount) already in gallery)" : "")
+            appData.images.append(contentsOf: allRestored)
+            restoreMessage = "Restored \(totalSuccess) images" + (totalFailure > 0 ? " (\(totalFailure) already in gallery)" : "")
             showRestoreConfirmation = true
             selectedDates.removeAll()
             isMultiSelectMode = false
@@ -299,15 +324,35 @@ struct ArchiveView: View {
 
     private func deleteSelectedArchives() async {
         let docs = await appData.fileService.documentsDirectory
-        for date in selectedDates {
-            let archiveURL = docs.appendingPathComponent(date)
-            do {
-                try await appData.fileService.removeItem(at: archiveURL)
-                await MainActor.run {
-                    customArchiveNames.removeValue(forKey: date)
+        let datesToDelete = Array(selectedDates)
+
+        await withTaskGroup(of: String?.self) { group in
+            for date in datesToDelete {
+                group.addTask {
+                    let archiveURL = docs.appendingPathComponent(date)
+                    do {
+                        try await appData.fileService.removeItem(at: archiveURL)
+                        return date
+                    } catch {
+                        print("Failed to delete archive \(date): \(error)")
+                        return nil
+                    }
                 }
-            } catch {
-                print("Failed to delete archive \(date): \(error)")
+            }
+
+            var deletedResults: [String] = []
+            for await deletedDate in group {
+                if let date = deletedDate {
+                    deletedResults.append(date)
+                }
+            }
+
+            if !deletedResults.isEmpty {
+                await MainActor.run {
+                    for date in deletedResults {
+                        customArchiveNames.removeValue(forKey: date)
+                    }
+                }
             }
         }
 
@@ -326,15 +371,34 @@ struct ArchiveView: View {
     private func deleteAllArchives() async {
         let archives = await appData.getArchivedDates()
         let docs = await appData.fileService.documentsDirectory
-        for archive in archives {
-            let archiveURL = docs.appendingPathComponent(archive)
-            do {
-                try await appData.fileService.removeItem(at: archiveURL)
-                await MainActor.run {
-                    customArchiveNames.removeValue(forKey: archive)
+
+        await withTaskGroup(of: String?.self) { group in
+            for archive in archives {
+                group.addTask {
+                    let archiveURL = docs.appendingPathComponent(archive)
+                    do {
+                        try await appData.fileService.removeItem(at: archiveURL)
+                        return archive
+                    } catch {
+                        print("Failed to delete archive \(archive): \(error)")
+                        return nil
+                    }
                 }
-            } catch {
-                print("Failed to delete archive \(archive): \(error)")
+            }
+
+            var deletedResults: [String] = []
+            for await deletedArchive in group {
+                if let archive = deletedArchive {
+                    deletedResults.append(archive)
+                }
+            }
+
+            if !deletedResults.isEmpty {
+                await MainActor.run {
+                    for archive in deletedResults {
+                        customArchiveNames.removeValue(forKey: archive)
+                    }
+                }
             }
         }
 
@@ -529,27 +593,47 @@ struct ArchivedImagesView: View {
     private func restoreImages(_ imageURLs: [URL]) async {
         let docs = await appData.fileService.documentsDirectory
         let imagesFolderURL = docs.appendingPathComponent("images")
-        var successCount = 0
 
         do {
             try await appData.fileService.createDirectory(at: imagesFolderURL)
-            for imageURL in imageURLs {
-                let destinationURL = imagesFolderURL.appendingPathComponent(
-                    imageURL.lastPathComponent)
-                if !appData.images.contains(where: { $0.fileURL == destinationURL }) {
-                    try? await appData.fileService.removeItem(at: destinationURL)
-                    try await appData.fileService.copyItem(at: imageURL, to: destinationURL)
-                    let capturedImage = CapturedImage(
-                        name: imageURL.deletingPathExtension().lastPathComponent,
-                        fileURL: destinationURL)
-                    await MainActor.run {
-                        appData.images.append(capturedImage)
+
+            let restoredImages = await withTaskGroup(of: CapturedImage?.self) { group in
+                for imageURL in imageURLs {
+                    group.addTask {
+                        let destinationURL = imagesFolderURL.appendingPathComponent(imageURL.lastPathComponent)
+
+                        let alreadyInGallery = await MainActor.run {
+                            appData.images.contains(where: { $0.fileURL == destinationURL })
+                        }
+
+                        if !alreadyInGallery {
+                            do {
+                                try? await appData.fileService.removeItem(at: destinationURL)
+                                try await appData.fileService.copyItem(at: imageURL, to: destinationURL)
+                                return CapturedImage(
+                                    name: imageURL.deletingPathExtension().lastPathComponent,
+                                    fileURL: destinationURL)
+                            } catch {
+                                print("Failed to restore image: \(error)")
+                                return nil
+                            }
+                        }
+                        return nil
                     }
-                    successCount += 1
                 }
+
+                var results: [CapturedImage] = []
+                for await image in group {
+                    if let image = image {
+                        results.append(image)
+                    }
+                }
+                return results
             }
+
             await MainActor.run {
-                restoreMessage = "Restored \(successCount) images"
+                appData.images.append(contentsOf: restoredImages)
+                restoreMessage = "Restored \(restoredImages.count) images"
                 showRestoreConfirmation = true
                 appData.hapticService.playNotification(type: .success)
             }
@@ -564,12 +648,17 @@ struct ArchivedImagesView: View {
     private func deleteSelectedImages() async {
         let docs = await appData.fileService.documentsDirectory
         let dateFolder = docs.appendingPathComponent(date)
+        let imagesToDelete = Array(selectedImages)
 
-        for imageURL in selectedImages {
-            do {
-                try await appData.fileService.removeItem(at: imageURL)
-            } catch {
-                print("Failed to delete image: \(error)")
+        await withTaskGroup(of: Void.self) { group in
+            for imageURL in imagesToDelete {
+                group.addTask {
+                    do {
+                        try await appData.fileService.removeItem(at: imageURL)
+                    } catch {
+                        print("Failed to delete image: \(error)")
+                    }
+                }
             }
         }
 

--- a/LANImageUploader/ArchiveView.swift
+++ b/LANImageUploader/ArchiveView.swift
@@ -265,39 +265,40 @@ struct ArchiveView: View {
             let restoredImages: [CapturedImage]
         }
 
-        let (totalSuccess, totalFailure, allRestored) = await withTaskGroup(of: RestorationResult.self) { group in
-            for date in datesToRestore {
+        let existingImageURLs = await MainActor.run {
+            Set(appData.images.map(\.fileURL))
+        }
+
+        var seenDestinationURLs = existingImageURLs
+        var imagesToRestore: [(source: URL, destination: URL)] = []
+        var skippedCount = 0
+
+        for date in datesToRestore {
+            let images = await appData.getImagesForDate(date)
+            for imageURL in images {
+                let destinationURL = imagesFolderURL.appendingPathComponent(imageURL.lastPathComponent)
+                if seenDestinationURLs.insert(destinationURL).inserted {
+                    imagesToRestore.append((source: imageURL, destination: destinationURL))
+                } else {
+                    skippedCount += 1
+                }
+            }
+        }
+
+        let (restoredCount, failedCount, allRestored) = await withTaskGroup(of: RestorationResult.self) { group in
+            for image in imagesToRestore {
                 group.addTask {
-                    let images = await self.appData.getImagesForDate(date)
-                    var localSuccess = 0
-                    var localFailure = 0
-                    var localRestored: [CapturedImage] = []
-
-                    for imageURL in images {
-                        let destinationURL = imagesFolderURL.appendingPathComponent(imageURL.lastPathComponent)
-
-                        let alreadyInGallery = await MainActor.run {
-                            self.appData.images.contains(where: { $0.fileURL == destinationURL })
-                        }
-
-                        if !alreadyInGallery {
-                            do {
-                                try? await self.appData.fileService.removeItem(at: destinationURL)
-                                try await self.appData.fileService.copyItem(at: imageURL, to: destinationURL)
-                                let capturedImage = CapturedImage(
-                                    name: imageURL.deletingPathExtension().lastPathComponent,
-                                    fileURL: destinationURL)
-                                localRestored.append(capturedImage)
-                                localSuccess += 1
-                            } catch {
-                                print("Failed to restore image \(imageURL.lastPathComponent): \(error)")
-                                localFailure += 1
-                            }
-                        } else {
-                            localFailure += 1
-                        }
+                    do {
+                        try? await self.appData.fileService.removeItem(at: image.destination)
+                        try await self.appData.fileService.copyItem(at: image.source, to: image.destination)
+                        let capturedImage = CapturedImage(
+                            name: image.source.deletingPathExtension().lastPathComponent,
+                            fileURL: image.destination)
+                        return RestorationResult(successCount: 1, failureCount: 0, restoredImages: [capturedImage])
+                    } catch {
+                        print("Failed to restore archived image: \(error)")
+                        return RestorationResult(successCount: 0, failureCount: 1, restoredImages: [])
                     }
-                    return RestorationResult(successCount: localSuccess, failureCount: localFailure, restoredImages: localRestored)
                 }
             }
 
@@ -314,7 +315,8 @@ struct ArchiveView: View {
 
         await MainActor.run {
             appData.images.append(contentsOf: allRestored)
-            restoreMessage = "Restored \(totalSuccess) images" + (totalFailure > 0 ? " (\(totalFailure) already in gallery)" : "")
+            let totalFailure = failedCount + skippedCount
+            restoreMessage = "Restored \(restoredCount) images" + (totalFailure > 0 ? " (\(totalFailure) already in gallery)" : "")
             showRestoreConfirmation = true
             selectedDates.removeAll()
             isMultiSelectMode = false
@@ -597,28 +599,32 @@ struct ArchivedImagesView: View {
         do {
             try await appData.fileService.createDirectory(at: imagesFolderURL)
 
+            let existingImageURLs = await MainActor.run {
+                Set(appData.images.map(\.fileURL))
+            }
+
+            var seenDestinationURLs = existingImageURLs
+            let imagesToRestore = imageURLs.compactMap { imageURL -> (source: URL, destination: URL)? in
+                let destinationURL = imagesFolderURL.appendingPathComponent(imageURL.lastPathComponent)
+                guard seenDestinationURLs.insert(destinationURL).inserted else {
+                    return nil
+                }
+                return (source: imageURL, destination: destinationURL)
+            }
+
             let restoredImages = await withTaskGroup(of: CapturedImage?.self) { group in
-                for imageURL in imageURLs {
+                for image in imagesToRestore {
                     group.addTask {
-                        let destinationURL = imagesFolderURL.appendingPathComponent(imageURL.lastPathComponent)
-
-                        let alreadyInGallery = await MainActor.run {
-                            appData.images.contains(where: { $0.fileURL == destinationURL })
+                        do {
+                            try? await appData.fileService.removeItem(at: image.destination)
+                            try await appData.fileService.copyItem(at: image.source, to: image.destination)
+                            return CapturedImage(
+                                name: image.source.deletingPathExtension().lastPathComponent,
+                                fileURL: image.destination)
+                        } catch {
+                            print("Failed to restore archived image: \(error)")
+                            return nil
                         }
-
-                        if !alreadyInGallery {
-                            do {
-                                try? await appData.fileService.removeItem(at: destinationURL)
-                                try await appData.fileService.copyItem(at: imageURL, to: destinationURL)
-                                return CapturedImage(
-                                    name: imageURL.deletingPathExtension().lastPathComponent,
-                                    fileURL: destinationURL)
-                            } catch {
-                                print("Failed to restore image: \(error)")
-                                return nil
-                            }
-                        }
-                        return nil
                     }
                 }
 


### PR DESCRIPTION
- Optimized `deleteSelectedArchives` and `deleteAllArchives` to use `TaskGroup`.
- Optimized `restoreSelectedArchives` to parallelize image restoration from multiple dates.
- Optimized `ArchivedImagesView` methods (`restoreImages`, `deleteSelectedImages`) for parallel execution.
- Batched `MainActor` updates across all optimized methods to reduce context-switching overhead.