### PR TITLE
⚡ Optimize `archiveImages` file I/O operations with concurrent task group

### DIFF
--- a/LANImageUploader/FileService.swift
+++ b/LANImageUploader/FileService.swift
@@ -71,15 +71,12 @@ final class FileService: FileServiceProtocol {
                     do {
                         try await self.actor.copyItem(at: image.fileURL, to: destinationURL)
                         return true
-                    } catch {
+                    } catch let error as CocoaError where error.code == .fileWriteFileExists {
                         // If file exists error, it's fine, we treat it as already saved.
+                        return false
+                    } catch {
                         // Other errors will be thrown and fail the group.
-                        let nsError = error as NSError
-                        if nsError.domain == NSCocoaErrorDomain && nsError.code == NSFileWriteFileExistsError {
-                            return false
-                        } else {
-                            throw error
-                        }
+                        throw error
                     }
                 }
             }

--- a/LANImageUploader/FileService.swift
+++ b/LANImageUploader/FileService.swift
@@ -57,21 +57,43 @@ final class FileService: FileServiceProtocol {
         let docs = await actor.documentsDirectory
         let datedFolderURL = docs.appendingPathComponent(dateString)
 
-        var savedCount = 0
-        var alreadySavedCount = 0
-
         try await actor.createDirectory(at: datedFolderURL)
-        for image in images {
-            let destinationURL = datedFolderURL.appendingPathComponent(image.fileURL.lastPathComponent)
-            if await !actor.fileExists(at: destinationURL) {
-                try await actor.copyItem(at: image.fileURL, to: destinationURL)
-                savedCount += 1
-            } else {
-                alreadySavedCount += 1
+
+        return try await withThrowingTaskGroup(of: Bool.self) { group in
+            var savedCount = 0
+            var alreadySavedCount = 0
+
+            for image in images {
+                group.addTask {
+                    let destinationURL = datedFolderURL.appendingPathComponent(image.fileURL.lastPathComponent)
+
+                    // To avoid TOCTOU race condition when parallelizing
+                    do {
+                        try await self.actor.copyItem(at: image.fileURL, to: destinationURL)
+                        return true
+                    } catch {
+                        // If file exists error, it's fine, we treat it as already saved.
+                        // Other errors will be thrown and fail the group.
+                        let nsError = error as NSError
+                        if nsError.domain == NSCocoaErrorDomain && nsError.code == NSFileWriteFileExistsError {
+                            return false
+                        } else {
+                            throw error
+                        }
+                    }
+                }
             }
+
+            for try await wasSaved in group {
+                if wasSaved {
+                    savedCount += 1
+                } else {
+                    alreadySavedCount += 1
+                }
+            }
+
+            return (savedCount, alreadySavedCount)
         }
-        
-        return (savedCount, alreadySavedCount)
     }
 
     /// Gets a list of archived date strings (YYYY-MM-DD).

--- a/LANImageUploaderTests/ArchiveImagesBenchmarkTests.swift
+++ b/LANImageUploaderTests/ArchiveImagesBenchmarkTests.swift
@@ -9,6 +9,7 @@ struct ArchiveImagesBenchmarkTests {
         // Setup mock images
         let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
 
         var images: [CapturedImage] = []
         for i in 0..<100 {

--- a/LANImageUploaderTests/ArchiveImagesBenchmarkTests.swift
+++ b/LANImageUploaderTests/ArchiveImagesBenchmarkTests.swift
@@ -27,7 +27,17 @@ struct ArchiveImagesBenchmarkTests {
 
         #expect(result.saved == 100)
 
-        // Cleanup
+        // Cleanup temp images
         try FileManager.default.removeItem(at: tempDir)
+
+        // Cleanup destination archived images to avoid leaking disk space and failing subsequent runs
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        let dateString = formatter.string(from: Date())
+        let docs = try FileManager.default.url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: false)
+        let datedFolderURL = docs.appendingPathComponent(dateString)
+        if FileManager.default.fileExists(atPath: datedFolderURL.path) {
+            try FileManager.default.removeItem(at: datedFolderURL)
+        }
     }
 }

--- a/LANImageUploaderTests/ArchiveImagesBenchmarkTests.swift
+++ b/LANImageUploaderTests/ArchiveImagesBenchmarkTests.swift
@@ -1,0 +1,33 @@
+import Testing
+import Foundation
+@testable import LANImageUploader
+
+struct ArchiveImagesBenchmarkTests {
+    @Test func benchmarkArchiveImages() async throws {
+        let fileService = FileService.shared
+
+        // Setup mock images
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+
+        var images: [CapturedImage] = []
+        for i in 0..<100 {
+            let fileURL = tempDir.appendingPathComponent("image\(i).jpg")
+            let data = Data(repeating: 0, count: 1024 * 1024) // 1MB
+            try data.write(to: fileURL)
+            images.append(CapturedImage(name: "image\(i)", fileURL: fileURL))
+        }
+
+        let startTime = CFAbsoluteTimeGetCurrent()
+
+        let result = try await fileService.archiveImages(images)
+
+        let timeElapsed = CFAbsoluteTimeGetCurrent() - startTime
+        print("Archive 100 1MB images took: \(timeElapsed) seconds")
+
+        #expect(result.saved == 100)
+
+        // Cleanup
+        try FileManager.default.removeItem(at: tempDir)
+    }
+}

--- a/LANImageUploaderTests/ArchiveImagesBenchmarkTests.swift
+++ b/LANImageUploaderTests/ArchiveImagesBenchmarkTests.swift
@@ -20,7 +20,7 @@ struct ArchiveImagesBenchmarkTests {
 
         let startTime = CFAbsoluteTimeGetCurrent()
 
-        let result = try await fileService.archiveImages(images)
+        let result = try await fileService.archiveImages(images, for: Date())
 
         let timeElapsed = CFAbsoluteTimeGetCurrent() - startTime
         print("Archive 100 1MB images took: \(timeElapsed) seconds")

--- a/LANImageUploaderTests/ArchiveImagesBenchmarkTests.swift
+++ b/LANImageUploaderTests/ArchiveImagesBenchmarkTests.swift
@@ -9,7 +9,6 @@ struct ArchiveImagesBenchmarkTests {
         // Setup mock images
         let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-        defer { try? FileManager.default.removeItem(at: tempDir) }
 
         var images: [CapturedImage] = []
         for i in 0..<100 {


### PR DESCRIPTION
💡 **What:** 
Optimized the `archiveImages` function in `FileService` to use a `withThrowingTaskGroup`. This parallelizes the file copying operations, eliminating the sequential loop that awaited on each file individually. To avoid TOCTOU (Time-Of-Check to Time-Of-Use) bugs, I removed the `fileExists` check and instead catch `NSFileWriteFileExistsError` locally in each task.

🎯 **Why:** 
Previously, saving large batches of images was unnecessarily slow because each file system copy operation blocked the next. Parallelizing these operations significantly speeds up the archival process, reducing user wait times and UI lockups. Catching errors rather than checking if file exists also eliminates race conditions in concurrent execution.

📊 **Measured Improvement:** 
Due to environment limitations, I was unable to compile the app and run the benchmark directly, so `ArchiveImagesBenchmarkTests.swift` was added to standard testing suite to allow testing the optimization moving forward. The expected improvement based on theory for 100 images goes from `O(N) * I/O latency` to `O(1) * I/O latency` (within device concurrency limits), likely a multi-second improvement depending on file sizes and storage speed.

---
*PR created automatically by Jules for task [14158877862647449543](https://jules.google.com/task/14158877862647449543) started by @janhcla*