### PR TITLE
🧹 Refactor OCRValidator CPR extraction regex logic

### DIFF
--- a/LANImageUploader/OCRValidator.swift
+++ b/LANImageUploader/OCRValidator.swift
@@ -28,7 +28,8 @@ enum OCRValidator {
     // Matches a valid DDMMYY date format and a 4-digit sequence, optionally separated by a dash.
     // DD: 01-31, MM: 01-12, YY: 00-99
     // Negative lookbehind and lookahead prevent matching inside longer digit sequences.
-    private static let cprRegex = try! NSRegularExpression(pattern: #"(?<!\d)((?:0[1-9]|[12]\d|3[01])(?:0[1-9]|1[0-2])\d{2})-?(\d{4})(?!\d)"#)
+    @available(iOS 16.0, *)
+    private static let cprRegex = /(?<!\d)(?<date>(?:0[1-9]|[12]\d|3[01])(?:0[1-9]|1[0-2])\d{2})-?(?<sequence>\d{4})(?!\d)/
 
     static func sanitizedText(from text: String, mode: OCRMode) -> String? {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -54,11 +55,12 @@ enum OCRValidator {
                 options: .regularExpression
             )
             
-            if let match = cprRegex.firstMatch(in: normalized, range: NSRange(normalized.startIndex..., in: normalized)) {
-                let nsString = normalized as NSString
-                let datePart = nsString.substring(with: match.range(at: 1))
-                let sequencePart = nsString.substring(with: match.range(at: 2))
-                return "\(datePart)-\(sequencePart)"
+            if #available(iOS 16.0, *) {
+                if let match = try? cprRegex.firstMatch(in: normalized) {
+                    return "\(match.date)-\(match.sequence)"
+                }
+            } else {
+                // Fallback for older iOS versions if necessary. In this project iOS 18 is assumed based on the PR comment.
             }
             
             return nil

--- a/LANImageUploader/OCRValidator.swift
+++ b/LANImageUploader/OCRValidator.swift
@@ -28,7 +28,7 @@ enum OCRValidator {
     // Matches a valid DDMMYY date format and a 4-digit sequence, optionally separated by a dash.
     // DD: 01-31, MM: 01-12, YY: 00-99
     // Negative lookbehind and lookahead prevent matching inside longer digit sequences.
-    private static let cprRegex = /(?<!\d)(?<date>(?:0[1-9]|[12]\d|3[01])(?:0[1-9]|1[0-2])\d{2})-?(?<sequence>\d{4})(?!\d)/
+    private static let cprRegex = try! NSRegularExpression(pattern: #"(?<!\d)((?:0[1-9]|[12]\d|3[01])(?:0[1-9]|1[0-2])\d{2})-?(\d{4})(?!\d)"#)
 
     static func sanitizedText(from text: String, mode: OCRMode) -> String? {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/LANImageUploader/OCRValidator.swift
+++ b/LANImageUploader/OCRValidator.swift
@@ -28,7 +28,7 @@ enum OCRValidator {
     // Matches a valid DDMMYY date format and a 4-digit sequence, optionally separated by a dash.
     // DD: 01-31, MM: 01-12, YY: 00-99
     // Negative lookbehind and lookahead prevent matching inside longer digit sequences.
-    private static let cprRegex = try! NSRegularExpression(pattern: #"(?<!\d)((?:0[1-9]|[12]\d|3[01])(?:0[1-9]|1[0-2])\d{2})-?(\d{4})(?!\d)"#)
+    private static let cprRegex = /(?<!\d)((?:0[1-9]|[12]\d|3[01])(0[1-9]|1[0-2])\d{2})-?(\d{4})(?!\d)/
 
     static func sanitizedText(from text: String, mode: OCRMode) -> String? {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/LANImageUploader/OCRValidator.swift
+++ b/LANImageUploader/OCRValidator.swift
@@ -49,17 +49,16 @@ enum OCRValidator {
                 options: .regularExpression
             )
             
-            let dashedPattern = #"\d{6}-\d{4}"#
-            if let match = normalized.range(of: dashedPattern, options: .regularExpression) {
-                return String(normalized[match])
-            }
-            
-            // Fallback: accept exactly 10 digits and normalize to DDMMYY-XXXX
-            let digitsOnly = normalized.filter { $0.isNumber }
-            if digitsOnly.count == 10 && normalized.range(of: #"^\d{10}$"#, options: .regularExpression) != nil {
-                let prefix = digitsOnly.prefix(6)
-                let suffix = digitsOnly.suffix(4)
-                return "\(prefix)-\(suffix)"
+            // Matches a valid DDMMYY date format and a 4-digit sequence, optionally separated by a dash.
+            // DD: 01-31, MM: 01-12, YY: 00-99
+            // Negative lookbehind and lookahead prevent matching inside longer digit sequences.
+            let cprPattern = #"(?<!\d)((?:0[1-9]|[12]\d|3[01])(?:0[1-9]|1[0-2])\d{2})-?(\d{4})(?!\d)"#
+            if let regex = try? NSRegularExpression(pattern: cprPattern),
+               let match = regex.firstMatch(in: normalized, range: NSRange(normalized.startIndex..., in: normalized)) {
+                let nsString = normalized as NSString
+                let datePart = nsString.substring(with: match.range(at: 1))
+                let sequencePart = nsString.substring(with: match.range(at: 2))
+                return "\(datePart)-\(sequencePart)"
             }
             
             return nil

--- a/LANImageUploader/OCRValidator.swift
+++ b/LANImageUploader/OCRValidator.swift
@@ -28,7 +28,7 @@ enum OCRValidator {
     // Matches a valid DDMMYY date format and a 4-digit sequence, optionally separated by a dash.
     // DD: 01-31, MM: 01-12, YY: 00-99
     // Negative lookbehind and lookahead prevent matching inside longer digit sequences.
-    private static let cprRegex = try! NSRegularExpression(pattern: #"(?<!\d)((?:0[1-9]|[12]\d|3[01])(?:0[1-9]|1[0-2])\d{2})-?(\d{4})(?!\d)"#)
+    private static let cprRegex = /(?<!\d)(?<date>(?:0[1-9]|[12]\d|3[01])(?:0[1-9]|1[0-2])\d{2})-?(?<sequence>\d{4})(?!\d)/
 
     static func sanitizedText(from text: String, mode: OCRMode) -> String? {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/LANImageUploader/OCRValidator.swift
+++ b/LANImageUploader/OCRValidator.swift
@@ -28,7 +28,7 @@ enum OCRValidator {
     // Matches a valid DDMMYY date format and a 4-digit sequence, optionally separated by a dash.
     // DD: 01-31, MM: 01-12, YY: 00-99
     // Negative lookbehind and lookahead prevent matching inside longer digit sequences.
-    private static let cprRegex = /(?<!\d)((?:0[1-9]|[12]\d|3[01])(0[1-9]|1[0-2])\d{2})-?(\d{4})(?!\d)/
+    private static let cprRegex = try! NSRegularExpression(pattern: #"(?<!\d)((?:0[1-9]|[12]\d|3[01])(?:0[1-9]|1[0-2])\d{2})-?(\d{4})(?!\d)"#)
 
     static func sanitizedText(from text: String, mode: OCRMode) -> String? {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/LANImageUploader/OCRValidator.swift
+++ b/LANImageUploader/OCRValidator.swift
@@ -4,6 +4,7 @@
 //
 
 import Foundation
+import OSLog
 
 enum OCRMode: String, CaseIterable, Identifiable {
     case full
@@ -28,8 +29,22 @@ enum OCRValidator {
     // Matches a valid DDMMYY date format and a 4-digit sequence, optionally separated by a dash.
     // DD: 01-31, MM: 01-12, YY: 00-99
     // Negative lookbehind and lookahead prevent matching inside longer digit sequences.
-    @available(iOS 16.0, *)
     private static let cprRegex = /(?<!\d)(?<date>(?:0[1-9]|[12]\d|3[01])(?:0[1-9]|1[0-2])\d{2})-?(?<sequence>\d{4})(?!\d)/
+
+    private static let logger = Logger(subsystem: Constants.bundleIdentifier, category: "OCRValidator")
+
+    private static func isValidDate(_ dateString: Substring) -> Bool {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "ddMMyy"
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        // Strict parsing so "310224" (Feb 31) fails
+        formatter.isLenient = false
+
+        if let _ = formatter.date(from: String(dateString)) {
+            return true
+        }
+        return false
+    }
 
     static func sanitizedText(from text: String, mode: OCRMode) -> String? {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -55,14 +70,13 @@ enum OCRValidator {
                 options: .regularExpression
             )
             
-            if #available(iOS 16.0, *) {
-                if let match = try? cprRegex.firstMatch(in: normalized) {
+            do {
+                if let match = try cprRegex.firstMatch(in: normalized), isValidDate(match.date) {
                     return "\(match.date)-\(match.sequence)"
                 }
-            } else {
-                // Fallback for older iOS versions if necessary. In this project iOS 18 is assumed based on the PR comment.
+            } catch {
+                logger.error("Regex matching failed: \(error.localizedDescription)")
             }
-            
             return nil
         }
     }

--- a/LANImageUploader/OCRValidator.swift
+++ b/LANImageUploader/OCRValidator.swift
@@ -25,6 +25,11 @@ enum OCRMode: String, CaseIterable, Identifiable {
 }
 
 enum OCRValidator {
+    // Matches a valid DDMMYY date format and a 4-digit sequence, optionally separated by a dash.
+    // DD: 01-31, MM: 01-12, YY: 00-99
+    // Negative lookbehind and lookahead prevent matching inside longer digit sequences.
+    private static let cprRegex = try! NSRegularExpression(pattern: #"(?<!\d)((?:0[1-9]|[12]\d|3[01])(?:0[1-9]|1[0-2])\d{2})-?(\d{4})(?!\d)"#)
+
     static func sanitizedText(from text: String, mode: OCRMode) -> String? {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
@@ -49,12 +54,7 @@ enum OCRValidator {
                 options: .regularExpression
             )
             
-            // Matches a valid DDMMYY date format and a 4-digit sequence, optionally separated by a dash.
-            // DD: 01-31, MM: 01-12, YY: 00-99
-            // Negative lookbehind and lookahead prevent matching inside longer digit sequences.
-            let cprPattern = #"(?<!\d)((?:0[1-9]|[12]\d|3[01])(?:0[1-9]|1[0-2])\d{2})-?(\d{4})(?!\d)"#
-            if let regex = try? NSRegularExpression(pattern: cprPattern),
-               let match = regex.firstMatch(in: normalized, range: NSRange(normalized.startIndex..., in: normalized)) {
+            if let match = cprRegex.firstMatch(in: normalized, range: NSRange(normalized.startIndex..., in: normalized)) {
                 let nsString = normalized as NSString
                 let datePart = nsString.substring(with: match.range(at: 1))
                 let sequencePart = nsString.substring(with: match.range(at: 2))

--- a/LANImageUploaderTests/TextValidationTests.swift
+++ b/LANImageUploaderTests/TextValidationTests.swift
@@ -9,15 +9,48 @@ import Foundation
 
 struct TextValidationTests {
 
-    @Test func testTextValidationLogic() {
+    @Test func testFullMode() {
         // Test valid cases
-        #expect(OCRValidator.isValid("Valid Name"))
-        #expect(OCRValidator.isValid("Image 123"))
+        #expect(OCRValidator.sanitizedText(from: "Valid Name", mode: .full) == "Valid Name")
+        #expect(OCRValidator.sanitizedText(from: " Image 123 ", mode: .full) == "Image 123")
         
         // Test invalid cases
-        #expect(!OCRValidator.isValid(""))
-        #expect(!OCRValidator.isValid("   ")) // Whitespace only
-        #expect(!OCRValidator.isValid("A")) // Too short
-        #expect(!OCRValidator.isValid("12")) // Too short
+        #expect(OCRValidator.sanitizedText(from: "", mode: .full) == nil)
+        #expect(OCRValidator.sanitizedText(from: "   ", mode: .full) == nil)
+        #expect(OCRValidator.sanitizedText(from: "A", mode: .full) == nil)
+    }
+
+    @Test func testNumbersMode() {
+        #expect(OCRValidator.sanitizedText(from: "123", mode: .numbers) == "123")
+        #expect(OCRValidator.sanitizedText(from: "1a2b3", mode: .numbers) == "123")
+        #expect(OCRValidator.sanitizedText(from: "abc", mode: .numbers) == nil)
+    }
+
+    @Test func testCPRMode() {
+        // Valid continuous
+        #expect(OCRValidator.sanitizedText(from: "3112991234", mode: .cpr) == "311299-1234")
+
+        // Valid dashed
+        #expect(OCRValidator.sanitizedText(from: "311299-1234", mode: .cpr) == "311299-1234")
+
+        // Valid continuous with text
+        #expect(OCRValidator.sanitizedText(from: "CPR: 3112991234", mode: .cpr) == "311299-1234")
+
+        // Valid dashed with alternative dashes and whitespace
+        #expect(OCRValidator.sanitizedText(from: "311299 \u{2014} 1234", mode: .cpr) == "311299-1234")
+
+        // Invalid dates
+        #expect(OCRValidator.sanitizedText(from: "321299-1234", mode: .cpr) == nil) // Invalid day
+        #expect(OCRValidator.sanitizedText(from: "311399-1234", mode: .cpr) == nil) // Invalid month
+        #expect(OCRValidator.sanitizedText(from: "001299-1234", mode: .cpr) == nil) // Invalid day
+
+        // Too short / Too long
+        #expect(OCRValidator.sanitizedText(from: "123456789", mode: .cpr) == nil) // 9 digits
+        #expect(OCRValidator.sanitizedText(from: "12345678901", mode: .cpr) == nil) // 11 digits
+        #expect(OCRValidator.sanitizedText(from: "121256-123", mode: .cpr) == nil)
+        #expect(OCRValidator.sanitizedText(from: "121256-12345", mode: .cpr) == nil)
+
+        // Matching correctly from larger text blocks
+        #expect(OCRValidator.sanitizedText(from: "ID: 150688-4321 is valid", mode: .cpr) == "150688-4321")
     }
 }

--- a/LANImageUploaderTests/TextValidationTests.swift
+++ b/LANImageUploaderTests/TextValidationTests.swift
@@ -43,6 +43,9 @@ struct TextValidationTests {
         #expect(OCRValidator.sanitizedText(from: "321299-1234", mode: .cpr) == nil) // Invalid day
         #expect(OCRValidator.sanitizedText(from: "311399-1234", mode: .cpr) == nil) // Invalid month
         #expect(OCRValidator.sanitizedText(from: "001299-1234", mode: .cpr) == nil) // Invalid day
+        #expect(OCRValidator.sanitizedText(from: "310224-1234", mode: .cpr) == nil) // Feb 31st
+        #expect(OCRValidator.sanitizedText(from: "290223-1234", mode: .cpr) == nil) // Feb 29th non-leap year
+        #expect(OCRValidator.sanitizedText(from: "290224-1234", mode: .cpr) == "290224-1234") // Feb 29th leap year
 
         // Too short / Too long
         #expect(OCRValidator.sanitizedText(from: "123456789", mode: .cpr) == nil) // 9 digits


### PR DESCRIPTION
🎯 **What:**
The CPR validation and formatting in `OCRValidator.swift` was refactored. The original implementation used a fallback that essentially searched for exactly 10 digits and formatted them as a CPR without verifying the correctness of the date components or ensuring it wasn't a subset of a longer number sequence. 
It has been replaced by a single robust regular expression `(?<!\d)((?:0[1-9]|[12]\d|3[01])(?:0[1-9]|1[0-2])\d{2})-?(\d{4})(?!\d)` which strictly tests for a date-like DDMMYY string structure (DD: 01-31, MM: 01-12, YY: 00-99) followed optionally by a dash and exactly 4 digits. It uses negative lookahead and lookbehind to prevent false positives within longer sequences.

💡 **Why:**
This improves readability by having one consolidated source of truth for the matching logic rather than multiple fallback conditions. By verifying structural validity (DDMMYY), it's far less error-prone and avoids matching invalid configurations or longer phone/account numbers that could happen to hold exactly 10 digits.

✅ **Verification:**
Manually verified the Regex logic via script (to compensate for lack of swift compiler in the sandbox).
Updated `TextValidationTests.swift` to use `#expect(OCRValidator.sanitizedText(from: mode:))` to thoroughly verify valid/invalid variants, including text noise, dashes, and whitespace differences, effectively capturing CPR validation requirements. (Unable to run xcodebuild due to absence of swift toolchain in sandbox).

✨ **Result:**
The `OCRValidator` now returns robust and cleanly parsed formatting with higher fidelity, leaving no ambiguity for arbitrary 10-digit text sequences, while preserving intended fallback extraction behavior on valid inputs.

---
*PR created automatically by Jules for task [2376510227299575285](https://jules.google.com/task/2376510227299575285) started by @janhcla*