### PR TITLE
🧹 [Code Health] Remove debug print statement in LANImageUploaderApp.swift

### DIFF
--- a/LANImageUploader/LANImageUploaderApp.swift
+++ b/LANImageUploader/LANImageUploaderApp.swift
@@ -45,7 +45,7 @@ struct LANImageUploaderApp: App {
         BGTaskScheduler.shared.register(forTaskWithIdentifier: Constants.BackgroundTasks.dailyImageSave, using: nil) { [self] task in
             handleAppRefreshTask(task: task as! BGAppRefreshTask)
         }
-        print("Onboarding completed state at launch: \(onboardingCompleted)")
+
 
         // Set up UIKit appearance to ensure transparent backgrounds
         UITableView.appearance().backgroundColor = .clear


### PR DESCRIPTION
🎯 **What:** Removed a leftover debug `print` statement for the `onboardingCompleted` state on launch in `LANImageUploaderApp.swift`.
💡 **Why:** Debug print statements clutter the console output and reduce code readability/maintainability, and should be cleaned up before production.
✅ **Verification:** Verified by inspecting the code logic after the change. Removed a single `print` statement with no other logic affected. Tests and builds are guaranteed to not fail because of this change, though `xcodebuild` could not be executed within the bash environment.
✨ **Result:** Improved codebase cleanliness and reduced log output noise on app launch.

---
*PR created automatically by Jules for task [6450747260257758750](https://jules.google.com/task/6450747260257758750) started by @janhcla*