### PR TITLE
🧹 Code Health: Remove debug print in NetworkMonitor

### DIFF
--- a/LANImageUploader/NetworkMonitor.swift
+++ b/LANImageUploader/NetworkMonitor.swift
@@ -44,7 +44,6 @@ final class NetworkMonitor: @unchecked Sendable {
     private func updateConnectionStatus(isConnected newValue: Bool) {
         guard isConnected != newValue else { return }
         isConnected = newValue
-        print("Network connection state changed to: \(isConnected)")
         // Post notification when network state changes
         NotificationCenter.default.post(name:.networkStatusChanged, object: nil)
     }


### PR DESCRIPTION
🎯 **What:** Removed an unnecessary debug print statement (`print("Network connection state changed to: \(isConnected)")`) in `LANImageUploader/NetworkMonitor.swift`.
💡 **Why:** Debug print statements clutter the logs and should be removed before production to improve the readability and maintainability of the codebase.
✅ **Verification:** Verified the code changes using `cat` and `grep`. Tests could not be run because `xcodebuild` is unavailable in the bash environment, but the change only removes a `print` statement, which is completely safe.
✨ **Result:** Improved code cleanliness by removing debugging artifacts.

---
*PR created automatically by Jules for task [1323543480322432747](https://jules.google.com/task/1323543480322432747) started by @janhcla*