### PR TITLE
🔒 Fix Data Exposure in ArchiveView Error Logging

### DIFF
--- a/LANImageUploader/ArchiveView.swift
+++ b/LANImageUploader/ArchiveView.swift
@@ -4,6 +4,9 @@
 //
 
 import SwiftUI
+import OSLog
+
+private let logger = Logger(subsystem: Constants.bundleIdentifier, category: "ArchiveView")
 
 // Custom struct to make URL Identifiable
 struct IdentifiableURL: Identifiable {
@@ -325,7 +328,7 @@ struct ArchiveView: View {
                             fileURL: image.destination)
                         return RestorationResult(successCount: 1, failureCount: 0, restoredImages: [capturedImage])
                     } catch {
-                        print("Failed to restore archived image: \(error)")
+                        logger.error("Failed to restore archived image: \(error, privacy: .private)")
                         return RestorationResult(successCount: 0, failureCount: 1, restoredImages: [])
                     }
                 }
@@ -365,7 +368,7 @@ struct ArchiveView: View {
                         try await appData.fileService.removeItem(at: archiveURL)
                         return date
                     } catch {
-                        print("Failed to delete archive \(date): \(error)")
+                        logger.error("Failed to delete archive \(date, privacy: .private): \(error, privacy: .private)")
                         return nil
                     }
                 }
@@ -411,7 +414,7 @@ struct ArchiveView: View {
                         try await appData.fileService.removeItem(at: archiveURL)
                         return archive
                     } catch {
-                        print("Failed to delete archive \(archive): \(error)")
+                        logger.error("Failed to delete archive \(archive, privacy: .private): \(error, privacy: .private)")
                         return nil
                     }
                 }
@@ -651,7 +654,7 @@ struct ArchivedImagesView: View {
                                 name: image.source.deletingPathExtension().lastPathComponent,
                                 fileURL: image.destination)
                         } catch {
-                            print("Failed to restore archived image: \(error)")
+                            logger.error("Failed to restore archived image: \(error, privacy: .private)")
                             return nil
                         }
                     }
@@ -691,7 +694,7 @@ struct ArchivedImagesView: View {
                     do {
                         try await appData.fileService.removeItem(at: imageURL)
                     } catch {
-                        print("Failed to delete image: \(error)")
+                        logger.error("Failed to delete image: \(error, privacy: .private)")
                     }
                 }
             }
@@ -708,7 +711,7 @@ struct ArchivedImagesView: View {
                 return
             }
         } catch {
-            print("Error checking/deleting empty archive folder: \(error)")
+            logger.error("Error checking/deleting empty archive folder: \(error, privacy: .private)")
         }
 
         await MainActor.run {


### PR DESCRIPTION
🎯 **What:** `ArchiveView` was using `print("... \(error)")` for error logging, which could expose sensitive data like file paths, network paths or other user information present in standard Swift errors.
⚠️ **Risk:** Printing errors directly to the console or system logs without privacy controls could lead to data exposure, violating the project's strict privacy rules as defined in AGENTS.md ("Never include personally identifiable data in logs").
🛡️ **Solution:** Replaced all `print` statements in `ArchiveView.swift` with a unified `OSLog` instance (`Logger`). All interpolated errors are now passed using the `privacy: .private` modifier to ensure sensitive data is redacted from system logs.

*Note: The test toolchain (`xcodebuild`, `swift`) was unavailable in this bash environment. The fix was manually verified using `grep` to ensure all `print` calls were successfully substituted with `logger.error` using `.private` privacy formatting.*

---
*PR created automatically by Jules for task [10082269605618117333](https://jules.google.com/task/10082269605618117333) started by @janhcla*