### PR TITLE
🧹 [Code Health] Replace generic print statements with OSLog in ArchiveView

### DIFF
--- a/LANImageUploader/ArchiveView.swift
+++ b/LANImageUploader/ArchiveView.swift
@@ -4,6 +4,9 @@
 //
 
 import SwiftUI
+import OSLog
+
+private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "LANImageUploader", category: "ArchiveView")
 
 // Custom struct to make URL Identifiable
 struct IdentifiableURL: Identifiable {
@@ -325,7 +328,7 @@ struct ArchiveView: View {
                             fileURL: image.destination)
                         return RestorationResult(successCount: 1, failureCount: 0, restoredImages: [capturedImage])
                     } catch {
-                        print("Failed to restore archived image: \(error)")
+                        logger.error("Failed to restore archived image: \(error, privacy: .public)")
                         return RestorationResult(successCount: 0, failureCount: 1, restoredImages: [])
                     }
                 }
@@ -651,7 +654,7 @@ struct ArchivedImagesView: View {
                                 name: image.source.deletingPathExtension().lastPathComponent,
                                 fileURL: image.destination)
                         } catch {
-                            print("Failed to restore archived image: \(error)")
+                            logger.error("Failed to restore archived image: \(error, privacy: .public)")
                             return nil
                         }
                     }


### PR DESCRIPTION
🎯 **What:** This PR replaces generic `print` statements in `LANImageUploader/ArchiveView.swift` with proper `OSLog` (`Logger`) structured logging.
💡 **Why:** Errors should be logged using `OSLog` instead of `print` to ensure they are captured in system logs, improving the maintainability and debuggability of the application.
✅ **Verification:** I manually inspected the modified file using bash commands and wrote a python script to parse the file's text to verify syntactical changes and string replacements were exact. Note: I couldn't run `xcodebuild` or the Swift test suite as those tools aren't available in this environment.
✨ **Result:** The `ArchiveView.swift` file now uses the idiomatic `Logger` API, and properly emits diagnostic error events to the system logs whenever archiving fails.

---
*PR created automatically by Jules for task [5972657585994691777](https://jules.google.com/task/5972657585994691777) started by @janhcla*