### PR TITLE
🔒 [Security Fix] Use secure Keychain accessibility attribute

### DIFF
--- a/LANImageUploader/PremiumAccess.swift
+++ b/LANImageUploader/PremiumAccess.swift
@@ -157,17 +157,11 @@ final class KeychainPremiumAccessStore: PremiumAccessPersisting {
             kSecAttrService as String: service,
             kSecAttrAccount as String: account
         ]
-        let attributes: [String: Any] = [
-            kSecValueData as String: valueData,
-            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock
-        ]
-
-        let status = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
-        if status == errSecSuccess { return }
+        SecItemDelete(query as CFDictionary)
 
         var addQuery = query
         addQuery[kSecValueData as String] = valueData
-        addQuery[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
+        addQuery[kSecAttrAccessible as String] = kSecAttrAccessibleWhenUnlockedThisDeviceOnly
         SecItemAdd(addQuery as CFDictionary, nil)
     }
 }


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
The `KeychainPremiumAccessStore` in `PremiumAccess.swift` was storing the premium user state with `kSecAttrAccessibleAfterFirstUnlock`. This allows access to the data when the device is locked, as long as it has been unlocked at least once after booting.

⚠️ **Risk:** The potential impact if left unfixed
While the stored data is only premium state and not highly sensitive credentials, using less secure keychain attributes is generally discouraged, and could potentially be modified or accessed by an attacker with physical access to a locked but previously unlocked device. In other contexts (like passwords), this could lead to full credential exposure.

🛡️ **Solution:** How the fix addresses the vulnerability
The code has been updated to use `kSecAttrAccessibleWhenUnlockedThisDeviceOnly`. This restricts data access strictly to times when the device is actively unlocked, and also prevents syncing this data via iCloud to other devices. The update logic was also refactored to use a safe `SecItemDelete` followed by `SecItemAdd` to ensure the accessibility change is properly applied, as `SecItemUpdate` can be unpredictable when mutating accessibility attributes on existing items.

Manual Testing: No Xcode environment was available to run unit tests natively in this sandbox, but the changes strictly utilize standard Apple Security framework API patterns and have been structurally verified.

---
*PR created automatically by Jules for task [16376747691709736886](https://jules.google.com/task/16376747691709736886) started by @janhcla*