### PR TITLE
🧪 Add test for FileService.getArchivedDates

### DIFF
--- a/LANImageUploaderTests/FileServiceTests.swift
+++ b/LANImageUploaderTests/FileServiceTests.swift
@@ -36,4 +36,43 @@ struct FileServiceTests {
 
         #expect(isMatch == isValid)
     }
+
+    @Test func testGetArchivedDates() async throws {
+        let fileService = FileService.shared
+        let docsDir = await fileService.documentsDirectory
+
+        let validDates = ["2023-05-15", "2024-01-01", "2024-12-31"]
+        let invalidDates = ["2024-1-1", "invalid", "2024-12-31-extra"]
+
+        // Clean up before test just in case
+        for date in validDates + invalidDates {
+            try? await fileService.removeItem(at: docsDir.appendingPathComponent(date))
+        }
+
+        // Create test directories
+        for date in validDates + invalidDates {
+            let url = docsDir.appendingPathComponent(date)
+            try await fileService.createDirectory(at: url)
+        }
+
+        let retrievedDates = await fileService.getArchivedDates()
+
+        // Cleanup after test
+        for date in validDates + invalidDates {
+            try? await fileService.removeItem(at: docsDir.appendingPathComponent(date))
+        }
+
+        // Verify
+        for validDate in validDates {
+            #expect(retrievedDates.contains(validDate))
+        }
+
+        for invalidDate in invalidDates {
+            #expect(!retrievedDates.contains(invalidDate))
+        }
+
+        // Check sorting (descending)
+        let filteredRetrieved = retrievedDates.filter { validDates.contains($0) }
+        #expect(filteredRetrieved == validDates.sorted(by: >))
+    }
 }


### PR DESCRIPTION
🎯 **What:** `FileService.getArchivedDates()` is now thoroughly tested. 
📊 **Coverage:** A new test `testGetArchivedDates` is introduced to test regex matching for dated directories by creating actual folders simulating valid and invalid date directories and querying them back utilizing the service. 
✨ **Result:** Better automated testing and coverage for date directory retrieval functionality using the Swift Testing framework.
*Note:* The xcodebuild and swift execution environment are unavailable inside the container, but the regular expressions logic is thoroughly validated utilizing Python tests along with rigorous code inspection for the test validation and regex checks.

---
*PR created automatically by Jules for task [12643960138573952919](https://jules.google.com/task/12643960138573952919) started by @janhcla*