### PR TITLE
🔒 Use OSLog instead of print statements in NetworkMonitor

### DIFF
--- a/LANImageUploader/NetworkMonitor.swift
+++ b/LANImageUploader/NetworkMonitor.swift
@@ -7,6 +7,9 @@
 
 import Network
 import SwiftUI
+import OSLog
+
+private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "LANImageUploader", category: "NetworkMonitor")
 @preconcurrency import ObjectiveC
 
 @preconcurrency
@@ -24,7 +27,7 @@ final class NetworkMonitor: @unchecked Sendable {
         self.monitor = NWPathMonitor()
         
         monitor.pathUpdateHandler = { [weak self] path in
-            print("Path update received - Status: \(path.status)")
+            logger.debug("Path update received - Status: \(String(describing: path.status))")
             Task { @MainActor [weak self] in
                 guard let self = self else { return }
                 self.updateConnectionStatus(isConnected: path.status == .satisfied)
@@ -36,7 +39,7 @@ final class NetworkMonitor: @unchecked Sendable {
             guard let self = self else { return }
             let initialConnected = self.monitor.currentPath.status == .satisfied
             self.updateConnectionStatus(isConnected: initialConnected)
-            print("NetworkMonitor initialized - Initial connected: \(initialConnected)")
+            logger.debug("NetworkMonitor initialized - Initial connected: \(initialConnected)")
         }
     }
 
@@ -44,7 +47,7 @@ final class NetworkMonitor: @unchecked Sendable {
     private func updateConnectionStatus(isConnected newValue: Bool) {
         guard isConnected != newValue else { return }
         isConnected = newValue
-        print("Network connection state changed to: \(isConnected)")
+        logger.debug("Network connection state changed to: \(isConnected)")
         // Post notification when network state changes
         NotificationCenter.default.post(name:.networkStatusChanged, object: nil)
     }
@@ -119,7 +122,7 @@ final class NetworkMonitor: @unchecked Sendable {
     @MainActor
     func checkCurrentStatus() {
         let path = monitor.currentPath
-        print("Current path status: \(path.status)")
+        logger.debug("Current path status: \(String(describing: path.status))")
         updateConnectionStatus(isConnected: path.status == .satisfied)
     }
 }


### PR DESCRIPTION
🎯 **What:** The `NetworkMonitor.swift` file contained several `print()` statements that could potentially expose sensitive connection status or app flow details to console outputs or crash logs.
⚠️ **Risk:** While the specific current logs (`path.status`, boolean connections state) might seem innocuous, relying on `print()` for network-related logging is a security anti-pattern. If additional network details (IPs, SSIDs, share names) were later added to these prints, they would be visible to anyone reading the system console or parsing crash logs.
🛡️ **Solution:** Replaced all `print()` calls in `NetworkMonitor.swift` with Apple's unified logging system (`OSLog`). Created a private `logger` instance specific to the module and category. The messages are now logged at the `.debug` level, providing granular control over log visibility and aligning with modern Apple platform security practices.

---
*PR created automatically by Jules for task [3259891630620175434](https://jules.google.com/task/3259891630620175434) started by @janhcla*