### PR TITLE
🧪 Add UtilitiesTests for LiquidGlassUtils and removingSuffix

### DIFF
--- a/LANImageUploader.xcodeproj/project.pbxproj
+++ b/LANImageUploader.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		A1F11E782D68B563001D57FD /* LANImageUploaderTests/Mocks/MockHapticFeedbackService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F11E792D68B563001D57FD /* LANImageUploaderTests/Mocks/MockHapticFeedbackService.swift */; };
 		D84A039256B548319427DEA1 /* RetakeReviewSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3756349C4CC9493AB85FAAEC /* RetakeReviewSheet.swift */; };
 		FB48E70D3A754C519AC58099 /* LANImageUploader/Services/PDFGenerationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9774F2F1B2748D3965BA4CC /* LANImageUploader/Services/PDFGenerationService.swift */; };
+		AABBCCDD1122334455667788 /* UtilitiesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8877665544332211DDCCBBAA /* UtilitiesTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -151,6 +152,7 @@
 		BB8CECC1C94B45D8BFE52199 /* GalleryModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GalleryModelsTests.swift; sourceTree = "<group>"; };
 		D2988FBC6891402F823C8784 /* UploadModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadModels.swift; sourceTree = "<group>"; };
 		F5BA9FD459774EC381644C3B /* UploadableFileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadableFileTests.swift; sourceTree = "<group>"; };
+		8877665544332211DDCCBBAA /* UtilitiesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilitiesTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -240,6 +242,7 @@
 		3DB370132D98048A003D8E4A /* LANImageUploaderTests */ = {
 			isa = PBXGroup;
 			children = (
+				8877665544332211DDCCBBAA /* UtilitiesTests.swift */,
 				F5BA9FD459774EC381644C3B /* UploadableFileTests.swift */,
 				BB8CECC1C94B45D8BFE52199 /* GalleryModelsTests.swift */,
 				3DB370122D98048A003D8E4A /* LANImageUploaderTests.swift */,
@@ -489,6 +492,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AABBCCDD1122334455667788 /* UtilitiesTests.swift in Sources */,
 				3DB370142D98048A003D8E4A /* LANImageUploaderTests.swift in Sources */,
 				A1F11E6F2D68B563001D57FD /* Mocks/MockFileService.swift in Sources */,
 				A1F11E702D68B563001D57FD /* Mocks/MockImageUploadService.swift in Sources */,

--- a/LANImageUploaderTests/UtilitiesTests.swift
+++ b/LANImageUploaderTests/UtilitiesTests.swift
@@ -1,0 +1,44 @@
+//
+//  UtilitiesTests.swift
+//  LANImageUploaderTests
+//
+
+import Testing
+import Foundation
+@testable import LANImageUploader
+
+struct UtilitiesTests {
+
+    @Test func testRemovingSuffix() {
+        #expect("hello.txt".removingSuffix(".txt") == "hello")
+        #expect("hello".removingSuffix(".txt") == "hello")
+        #expect("".removingSuffix(".txt") == "")
+    }
+
+    @Test func testCalculateRefractionOffset() {
+        // angle = 0, tan(0) = 0
+        let offset0 = LiquidGlassUtils.calculateRefractionOffset(depth: 10, angle: 0)
+        #expect(offset0.width == 0)
+        #expect(offset0.height == 0)
+
+        // angle = 45, tan(45) = 1
+        let offset45 = LiquidGlassUtils.calculateRefractionOffset(depth: 10, angle: 45)
+        #expect(abs(offset45.width - 10) < 0.0001)
+        #expect(abs(offset45.height - 10) < 0.0001)
+
+        // angle = -45, tan(-45) = -1
+        let offsetMinus45 = LiquidGlassUtils.calculateRefractionOffset(depth: 10, angle: -45)
+        #expect(abs(offsetMinus45.width - -10) < 0.0001)
+        #expect(abs(offsetMinus45.height - -10) < 0.0001)
+
+        // angle = 30, tan(30) = 0.57735...
+        let offset30 = LiquidGlassUtils.calculateRefractionOffset(depth: 10, angle: 30)
+        #expect(abs(offset30.width - 5.7735) < 0.001)
+        #expect(abs(offset30.height - 5.7735) < 0.001)
+
+        // depth = 0
+        let offsetDepth0 = LiquidGlassUtils.calculateRefractionOffset(depth: 0, angle: 45)
+        #expect(offsetDepth0.width == 0)
+        #expect(offsetDepth0.height == 0)
+    }
+}


### PR DESCRIPTION
🎯 **What:** Testing gaps were identified in `Utilities.swift` for `LiquidGlassUtils.calculateRefractionOffset` and `removingSuffix`. These static helper methods and string extensions lacked dedicated unit tests.

📊 **Coverage:** The new tests cover:
1. `calculateRefractionOffset(depth:angle:)` ensuring output sizes calculate accurate `width` and `height` dimensions utilizing trigonometric identities (`tan()`) for varying degrees (0, 30, 45, -45) and zero depth cases.
2. `removingSuffix(_:)` assuring correct substring removal when suffix exists, no-op when non-existent, and handles empty strings safely.

✨ **Result:** The logic encapsulated within `Utilities.swift` is now reliably tested, preventing future regressions or mathematical calculation errors with the liquid glass effect behaviors and formatting. Tests are executed deterministic validation against absolute decimal values.

---
*PR created automatically by Jules for task [8447070910623077670](https://jules.google.com/task/8447070910623077670) started by @janhcla*