### PR TITLE
⚡ Optimize crop editor image loading to be asynchronous

### DIFF
--- a/LANImageUploader/GalleryView.swift
+++ b/LANImageUploader/GalleryView.swift
@@ -162,11 +162,9 @@ struct GalleryView: View {
                 )
             }
             .sheet(item: $cropEditingItem) { item in
-                if let capturedImage = item.capturedImage,
-                   let source = UIImage(contentsOfFile: capturedImage.fileURL.path) {
-                    CropEditorView(
-                        sourceImage: source,
-                        initialCrop: capturedImage.crop ?? .fullFrame,
+                if let capturedImage = item.capturedImage {
+                    AsyncCropEditorContainer(
+                        capturedImage: capturedImage,
                         onCancel: { cropEditingItem = nil },
                         onSave: { crop in
                             appData.updateCrop(for: capturedImage.id, crop: crop)
@@ -755,6 +753,59 @@ struct ReorderDropDelegate: DropDelegate {
     func performDrop(info: DropInfo) -> Bool {
         draggedItem = nil
         return true
+    }
+}
+
+
+struct AsyncCropEditorContainer: View {
+    let capturedImage: CapturedImage
+    let onCancel: () -> Void
+    let onSave: (DocumentCrop) -> Void
+
+    @State private var sourceImage: UIImage? = nil
+    @State private var hasError = false
+
+    var body: some View {
+        Group {
+            if let sourceImage = sourceImage {
+                CropEditorView(
+                    sourceImage: sourceImage,
+                    initialCrop: capturedImage.crop ?? .fullFrame,
+                    onCancel: onCancel,
+                    onSave: onSave
+                )
+            } else if hasError {
+                VStack(spacing: 16) {
+                    Text("Failed to load image.")
+                        .foregroundColor(.white)
+                    Button("Cancel", action: onCancel)
+                        .buttonStyle(.borderedProminent)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(Color.black.ignoresSafeArea())
+            } else {
+                VStack {
+                    ProgressView("Loading image...")
+                        .tint(.white)
+                        .foregroundColor(.white)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(Color.black.ignoresSafeArea())
+                .task {
+                    let image = await Task.detached(priority: .userInitiated) {
+                        UIImage(contentsOfFile: capturedImage.fileURL.path)
+                    }.value
+
+                    await MainActor.run {
+                        if let image = image {
+                            self.sourceImage = image
+                        } else {
+                            self.hasError = true
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/LANImageUploaderTests/GalleryViewTests.swift
+++ b/LANImageUploaderTests/GalleryViewTests.swift
@@ -1,0 +1,7 @@
+// Just testing compilation basically
+import SwiftUI
+@testable import LANImageUploader
+
+func testCompilation() {
+   // empty
+}

--- a/LANImageUploaderTests/ImageLoadBenchmarkTests.swift
+++ b/LANImageUploaderTests/ImageLoadBenchmarkTests.swift
@@ -1,0 +1,30 @@
+import Testing
+import UIKit
+import Foundation
+@testable import LANImageUploader
+
+struct ImageLoadBenchmarkTests {
+    @Test @MainActor func benchmarkSyncImageLoad() async throws {
+        let tempDir = FileManager.default.temporaryDirectory
+        let fileURL = tempDir.appendingPathComponent("largeImage.jpg")
+
+        let rect = CGRect(x: 0, y: 0, width: 4000, height: 4000)
+        UIGraphicsBeginImageContext(rect.size)
+        let context = UIGraphicsGetCurrentContext()!
+        context.setFillColor(UIColor.red.cgColor)
+        context.fill(rect)
+        let image = UIGraphicsGetImageFromCurrentImageContext()!
+        UIGraphicsEndImageContext()
+
+        let data = image.jpegData(compressionQuality: 1.0)!
+        try data.write(to: fileURL)
+
+        let startTime = CFAbsoluteTimeGetCurrent()
+        _ = UIImage(contentsOfFile: fileURL.path)
+        let timeElapsed = CFAbsoluteTimeGetCurrent() - startTime
+
+        print("Sync image load took: \(timeElapsed) seconds on MainThread")
+
+        try FileManager.default.removeItem(at: fileURL)
+    }
+}


### PR DESCRIPTION
💡 **What:** Moved `UIImage(contentsOfFile:)` in `GalleryView` to an asynchronous task (`AsyncCropEditorContainer`) to avoid blocking the main thread when presenting the crop editor sheet. Also handled failure gracefully.
🎯 **Why:** To eliminate UI stutters when opening large images for crop editing.
📊 **Measured Improvement:** We created a `ImageLoadBenchmarkTests` test in `LANImageUploaderTests` which we cannot run locally via `xcodebuild` due to the toolchain not being present. We will document the theoretical performance improvement instead. I/O on the main thread is a well-known SwiftUI performance anti-pattern. Moving large file reads off the main thread directly improves frame rates and reduces stuttering when presenting sheets.

---
*PR created automatically by Jules for task [9469379621359896277](https://jules.google.com/task/9469379621359896277) started by @janhcla*