### PR TITLE
🧪 Add tests for String.removingSuffix

### DIFF
--- a/LANImageUploader.xcodeproj/project.pbxproj
+++ b/LANImageUploader.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		3DB3700F2D98046E003D8E4C /* NetworkMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DB36FF32D98046E003D8E4A /* NetworkMonitor.swift */; };
 		3DB370112D98046E003D8E4A /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DB36FF52D98046E003D8E4A /* SettingsView.swift */; };
 		3DB370142D98048A003D8E4A /* LANImageUploaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DB370122D98048A003D8E4A /* LANImageUploaderTests.swift */; };
+		DEADBEEF1234567890ABCDE0 /* UtilitiesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEADBEEF1234567890ABCDEF /* UtilitiesTests.swift */; };
 		3DB370182D980499003D8E4A /* LANImageUploaderUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DB370162D980499003D8E4A /* LANImageUploaderUITestsLaunchTests.swift */; };
 		3DB370192D980499003D8E4A /* LANImageUploaderUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DB370152D980499003D8E4A /* LANImageUploaderUITests.swift */; };
 		5EA1443F24F74F18AE377E9E /* UploadModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2988FBC6891402F823C8784 /* UploadModels.swift */; };
@@ -151,6 +152,7 @@
 		BB8CECC1C94B45D8BFE52199 /* GalleryModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GalleryModelsTests.swift; sourceTree = "<group>"; };
 		D2988FBC6891402F823C8784 /* UploadModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadModels.swift; sourceTree = "<group>"; };
 		F5BA9FD459774EC381644C3B /* UploadableFileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadableFileTests.swift; sourceTree = "<group>"; };
+		DEADBEEF1234567890ABCDEF /* UtilitiesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilitiesTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -241,6 +243,7 @@
 			isa = PBXGroup;
 			children = (
 				F5BA9FD459774EC381644C3B /* UploadableFileTests.swift */,
+				DEADBEEF1234567890ABCDEF /* UtilitiesTests.swift */,
 				BB8CECC1C94B45D8BFE52199 /* GalleryModelsTests.swift */,
 				3DB370122D98048A003D8E4A /* LANImageUploaderTests.swift */,
 				A1F11E6C2D68B563001D57FD /* Mocks/MockFileService.swift */,
@@ -490,6 +493,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3DB370142D98048A003D8E4A /* LANImageUploaderTests.swift in Sources */,
+				DEADBEEF1234567890ABCDE0 /* UtilitiesTests.swift in Sources */,
 				A1F11E6F2D68B563001D57FD /* Mocks/MockFileService.swift in Sources */,
 				A1F11E702D68B563001D57FD /* Mocks/MockImageUploadService.swift in Sources */,
 				A1F11E712D68B563001D57FD /* Mocks/MockNetworkDiscovery.swift in Sources */,

--- a/LANImageUploaderTests/UtilitiesTests.swift
+++ b/LANImageUploaderTests/UtilitiesTests.swift
@@ -1,0 +1,40 @@
+//
+//  UtilitiesTests.swift
+//  LANImageUploaderTests
+//
+
+import Testing
+import Foundation
+@testable import LANImageUploader
+
+struct UtilitiesTests {
+
+    @Test func testRemovingSuffix() {
+        // Happy path: Suffix exists
+        #expect("filename.jpg".removingSuffix(".jpg") == "filename")
+        #expect("document.pdf".removingSuffix(".pdf") == "document")
+        #expect("image.jpeg".removingSuffix(".jpg") == "image.jpeg") // Doesn't match exact suffix
+
+        // Edge cases
+        // 1. Suffix doesn't exist
+        #expect("filename".removingSuffix(".jpg") == "filename")
+
+        // 2. Empty string
+        #expect("".removingSuffix(".jpg") == "")
+
+        // 3. Empty suffix
+        #expect("filename".removingSuffix("") == "filename")
+
+        // 4. String equals suffix
+        #expect(".jpg".removingSuffix(".jpg") == "")
+
+        // 5. Suffix is longer than the string
+        #expect("a".removingSuffix("abc") == "a")
+
+        // 6. Suffix with special characters
+        #expect("hello world!!!".removingSuffix("!!!") == "hello world")
+
+        // 7. Case sensitivity (should be case sensitive)
+        #expect("filename.JPG".removingSuffix(".jpg") == "filename.JPG")
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: Missing tests for `String.removingSuffix` in `Utilities.swift`.
📊 **Coverage:** Covered happy paths (suffix exists), edge cases (suffix doesn't exist, empty string, empty suffix, string equals suffix, suffix longer than string, suffix with special characters, case sensitivity). Tests added to a new file `UtilitiesTests.swift` and properly integrated into the Xcode project file.
✨ **Result:** Improved test coverage for core string manipulation utilities. Note: Since `xcodebuild` is unavailable in the execution environment, equivalent tests were run and passed in Python to verify logic correctness before including the Swift tests.

---
*PR created automatically by Jules for task [10861201542649205400](https://jules.google.com/task/10861201542649205400) started by @janhcla*