### PR TITLE
[codex] Fix gallery PDF upload flow

### DIFF
--- a/LANImageUploader/GalleryView.swift
+++ b/LANImageUploader/GalleryView.swift
@@ -211,13 +211,13 @@ struct GalleryView: View {
                 )
             }
             .navigationDestination(isPresented: $navigateToUpload) {
-                UploadView().environmentObject(appData)
+                UploadView(fallbackToGalleryImages: false).environmentObject(appData)
             }
             .safeAreaInset(edge: .bottom) {
                 if isMultiSelectMode && !appData.selectedImageIDs.isEmpty {
                     MultiSelectToolbarView(
                         appData: appData,
-                        onUpload: uploadSelectedItems,
+                        onUpload: uploadSelectedItemsForCurrentOutputMode,
                         onDelete: deleteSelectedItems,
                         onRename: {
                             imageName = ""
@@ -395,6 +395,15 @@ struct GalleryView: View {
         let selectedIDs = appData.selectedImageIDs
         let selectedItems = galleryItems.filter { selectedIDs.contains($0.id) }
         uploadItems(selectedItems)
+    }
+
+    func uploadSelectedItemsForCurrentOutputMode() {
+        if outputMode == .singlePDF {
+            imageName = ""
+            isShowingPDFNamingSheet = true
+        } else {
+            uploadSelectedItems()
+        }
     }
 
     func uploadItems(_ items: [GalleryItem]) {
@@ -678,7 +687,10 @@ struct GalleryView: View {
             maxPixelDimension: appData.pdfCompressionLevel.maxPixelDimension
         )
 
-        let itemsToProcess = galleryItems
+        let selectedIDs = appData.selectedImageIDs
+        let itemsToProcess = selectedIDs.isEmpty
+            ? galleryItems
+            : galleryItems.filter { selectedIDs.contains($0.id) }
         let finalName = imageName
 
         Task {
@@ -698,6 +710,8 @@ struct GalleryView: View {
 
                 await MainActor.run {
                     appData.pendingUploadFiles = [uploadFile]
+                    appData.selectedImageIDs.removeAll()
+                    isMultiSelectMode = false
                     isGeneratingPDF = false
                     isShowingPDFNamingSheet = false
                     imageName = ""

--- a/LANImageUploader/ImageUploadService.swift
+++ b/LANImageUploader/ImageUploadService.swift
@@ -209,7 +209,7 @@ final class ImageUploadService: ImageUploadServiceProtocol {
         expectedSize: Int
     ) async throws -> Bool {
         let attributes = try await client.attributesOfItem(atPath: path)
-        guard let size = attributes[.fileSizeKey] as? NSNumber else {
+        guard let size = attributes[URLResourceKey.fileSizeKey] as? NSNumber else {
             return false
         }
         return size.intValue == expectedSize

--- a/LANImageUploader/ImageUploadService.swift
+++ b/LANImageUploader/ImageUploadService.swift
@@ -129,20 +129,7 @@ final class ImageUploadService: ImageUploadServiceProtocol {
             
             let targetDir = settings.targetDirectory?.trimmingCharacters(in: .init(charactersIn: "/\\")) ?? ""
 
-            // Name sanitization and extension handling
-            var sanitizedName = file.name.trimmingCharacters(in: .whitespacesAndNewlines)
-            sanitizedName = sanitizedName.replacingOccurrences(of: "/", with: "_").replacingOccurrences(of: "\\", with: "_")
-            if sanitizedName.isEmpty {
-                sanitizedName = file.kind.displayName
-            }
-
-            // Remove duplicate extension if user typed it
-            let lowerName = sanitizedName.lowercased()
-            if lowerName.hasSuffix("." + file.kind.fileExtension) {
-                sanitizedName = String(sanitizedName.dropLast(file.kind.fileExtension.count + 1))
-            }
-
-            let destinationName = "\(sanitizedName).\(file.kind.fileExtension)"
+            let destinationName = destinationFileName(for: file)
             let destinationPath = targetDir.isEmpty ? destinationName : "\(targetDir)/\(destinationName)"
 
             // Check for duplicates if not overwriting
@@ -151,9 +138,10 @@ final class ImageUploadService: ImageUploadServiceProtocol {
                 do {
                     let contents = try await client.contentsOfDirectory(atPath: parentPath)
                     if contents.contains(where: { $0.name == destinationName }) {
-                        try? await client.disconnectShare()
                         throw UploadError.fileAlreadyExists(destinationName)
                     }
+                } catch let error as UploadError {
+                    throw error
                 } catch {
                     // Ignore if parentPath doesn't exist yet, we'll catch it below
                 }
@@ -168,19 +156,63 @@ final class ImageUploadService: ImageUploadServiceProtocol {
                 }
             }
 
-            // Perform the upload
-            try await client.write(data: fileData, toPath: destinationPath) { progressBytes in
-                let totalSize = Double(fileData.count)
-                let progressFraction = totalSize > 0 ? Double(progressBytes) / totalSize : 0.0
-                onProgress(progressFraction)
-                return true
+            // Perform the upload. Some SMB servers can surface a late fsync/write error
+            // after the complete file has been committed, so verify the remote size before
+            // reporting failure.
+            do {
+                try await client.write(data: fileData, toPath: destinationPath) { progressBytes in
+                    let totalSize = Double(fileData.count)
+                    let progressFraction = totalSize > 0 ? Double(progressBytes) / totalSize : 0.0
+                    onProgress(progressFraction)
+                    return true
+                }
+            } catch {
+                let writeError = error
+                if (try? await remoteFileMatchesExpectedSize(
+                    client: client,
+                    path: destinationPath,
+                    expectedSize: fileData.count
+                )) == true {
+                    onProgress(1.0)
+                } else {
+                    throw writeError
+                }
             }
 
             try? await client.disconnectShare()
         } catch {
             try? await client.disconnectShare()
-            throw mapUnderlyingError(error, fileName: "\(file.name).\(file.kind.fileExtension)")
+            throw mapUnderlyingError(error, fileName: destinationFileName(for: file))
         }
+    }
+
+    private func destinationFileName(for file: UploadableFile) -> String {
+        var sanitizedName = file.name.trimmingCharacters(in: .whitespacesAndNewlines)
+        sanitizedName = sanitizedName
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "\\", with: "_")
+        if sanitizedName.isEmpty {
+            sanitizedName = file.kind.displayName
+        }
+
+        let lowerName = sanitizedName.lowercased()
+        if lowerName.hasSuffix("." + file.kind.fileExtension) {
+            sanitizedName = String(sanitizedName.dropLast(file.kind.fileExtension.count + 1))
+        }
+
+        return "\(sanitizedName).\(file.kind.fileExtension)"
+    }
+
+    private func remoteFileMatchesExpectedSize(
+        client: SMB2Manager,
+        path: String,
+        expectedSize: Int
+    ) async throws -> Bool {
+        let attributes = try await client.attributesOfItem(atPath: path)
+        guard let size = attributes[.fileSizeKey] as? NSNumber else {
+            return false
+        }
+        return size.intValue == expectedSize
     }
     
     private func mapUnderlyingError(_ error: Error, fileName: String) -> UploadError {

--- a/LANImageUploader/NamingSheet.swift
+++ b/LANImageUploader/NamingSheet.swift
@@ -43,9 +43,10 @@ struct NamingSheet: View {
                         .overlay(alignment: .trailing) {
                             HStack {
                                 if !imageName.isEmpty {
-                                    Button(action: { 
+                                    Button(action: {
                                         appData.hapticService.playSelection()
                                         imageName = ""
+                                        appData.imageName = ""
                                     }) {
                                         Image(systemName: "xmark.circle.fill")
                                             .foregroundStyle(.gray)
@@ -55,6 +56,7 @@ struct NamingSheet: View {
                                 Button(action: {
                                     appData.hapticService.playSelection()
                                     isTextFieldFocused = false
+                                    appData.imageName = ""
                                     withAnimation(.spring()) {
                                         isScanningOCR.toggle()
                                     }
@@ -123,6 +125,7 @@ struct NamingSheet: View {
         }
         .onAppear {
             isTextFieldFocused = true
+            appData.imageName = imageName
         }
         .onChange(of: appData.imageName) { _, newValue in
             imageName = newValue

--- a/LANImageUploader/NamingSheet.swift
+++ b/LANImageUploader/NamingSheet.swift
@@ -56,7 +56,9 @@ struct NamingSheet: View {
                                 Button(action: {
                                     appData.hapticService.playSelection()
                                     isTextFieldFocused = false
-                                    appData.imageName = ""
+                                    if !isScanningOCR {
+                                        appData.imageName = ""
+                                    }
                                     withAnimation(.spring()) {
                                         isScanningOCR.toggle()
                                     }

--- a/LANImageUploader/UploadView.swift
+++ b/LANImageUploader/UploadView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct UploadView: View {
+    let fallbackToGalleryImages: Bool
     @EnvironmentObject var appData: AppData
     @State private var uploadStatuses: [UUID: UploadStatus] = [:]
     @State private var navigateToSettings = false
@@ -18,6 +19,7 @@ struct UploadView: View {
         if let pending = appData.pendingUploadFiles {
             return pending
         }
+        guard fallbackToGalleryImages else { return [] }
         return appData.images.map {
             UploadableFile(id: $0.id, name: $0.name, fileURL: $0.fileURL, kind: .jpeg)
         }
@@ -36,6 +38,10 @@ struct UploadView: View {
     @State private var duplicateFile: UploadableFile?
     @State private var overwriteConfirmed = false
     @State private var navigateToFullUnlock = false
+
+    init(fallbackToGalleryImages: Bool = true) {
+        self.fallbackToGalleryImages = fallbackToGalleryImages
+    }
 
     var areSettingsComplete: Bool {
         !appData.settings.serverIP.isEmpty && !appData.settings.shareName.isEmpty &&


### PR DESCRIPTION
## Summary
- keep Gallery-originated uploads restricted to the explicit pending upload queue so Create PDF & Upload cannot fall back to uploading gallery JPEGs
- make Single PDF mode work for selected uploads and clear selection state after PDF queue creation
- preserve repeated CPR OCR capture by resetting the shared naming value before scanning
- harden SMB upload handling for duplicate files and late write/fsync errors after a complete remote file has been written

## Root Cause
The Gallery-to-Upload route reused UploadView's default fallback behavior. If pendingUploadFiles was missing or stale during a Gallery PDF workflow, UploadView could fall back to appData.images and upload separate JPEG files. Duplicate detection also swallowed fileAlreadyExists inside its own do/catch, which could turn a duplicate into a generic SMB error.

## Validation
- git diff --check
- xcodebuild -project LANImageUploader.xcodeproj -scheme LANImageUploader -destination "platform=iOS Simulator,name=iPhone 17 Pro" -configuration Debug -skipPackagePluginValidation -skipMacroValidation build
- xcodebuild -project LANImageUploader.xcodeproj -scheme LANImageUploader -destination "platform=iOS Simulator,name=iPhone 17 Pro" -configuration Debug -skipPackagePluginValidation -skipMacroValidation test
