### PR TITLE
[codex] Refresh onboarding and Help experience

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ htmlcov/
 !.vscode/extensions.json
 *.swp
 *~
+.superpowers/

--- a/LANImageUploader/AppBackground.swift
+++ b/LANImageUploader/AppBackground.swift
@@ -65,6 +65,42 @@ struct BackgroundContainerView<Content: View>: View {
 
 // MARK: - iOS 26 Liquid Glass
 
+struct AppGlassCard<Content: View>: View {
+    let tint: Color?
+    @ViewBuilder let content: Content
+
+    init(tint: Color? = nil, @ViewBuilder content: () -> Content) {
+        self.tint = tint
+        self.content = content()
+    }
+
+    var body: some View {
+        content
+            .padding(18)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .glassEffect(
+                tint.map { .regular.tint($0.opacity(0.14)) } ?? .regular,
+                in: .rect(cornerRadius: 24)
+            )
+    }
+}
+
+struct AppSymbolTile: View {
+    let systemImage: String
+    let tint: Color
+    var size: CGFloat = 64
+
+    var body: some View {
+        Image(systemName: systemImage)
+            .font(.system(size: size * 0.42, weight: .semibold))
+            .foregroundStyle(.white)
+            .frame(width: size, height: size)
+            .background(tint.gradient, in: RoundedRectangle(cornerRadius: size * 0.32, style: .continuous))
+            .shadow(color: tint.opacity(0.28), radius: 18, y: 10)
+            .accessibilityHidden(true)
+    }
+}
+
 struct GlassContainer<Content: View>: View {
     let cornerRadius: CGFloat
     @ViewBuilder let content: Content

--- a/LANImageUploader/ButtonStyles.swift
+++ b/LANImageUploader/ButtonStyles.swift
@@ -51,3 +51,25 @@ struct BlueButtonStyle: ButtonStyle {
         LiquidButtonStyle(backgroundColor: .blue).makeBody(configuration: configuration)
     }
 }
+
+struct FullWidthGlassButtonLabel: View {
+    let title: String
+    let systemImage: String?
+
+    init(_ title: String, systemImage: String? = nil) {
+        self.title = title
+        self.systemImage = systemImage
+    }
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Text(title)
+            if let systemImage {
+                Image(systemName: systemImage)
+            }
+        }
+        .font(.headline)
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 7)
+    }
+}

--- a/LANImageUploader/HelpGuideView.swift
+++ b/LANImageUploader/HelpGuideView.swift
@@ -2,43 +2,679 @@
 //  HelpGuideView.swift
 //  LANImageUploader
 //
-//  Created by Jan Hagen Clausen on 22/02/2025.
-//
 
 import SwiftUI
 
 struct HelpGuideView: View {
-    @Environment(\.dismiss) var dismiss
-    @AppStorage("onboardingCompleted") var onboardingCompleted: Bool = false
+    @Environment(\.dismiss) private var dismiss
+    @AppStorage(Constants.UserDefaults.onboardingCompleted) private var onboardingCompleted = false
+    @State private var searchText = ""
+
+    private var searchResults: [HelpArticle] {
+        HelpContent.search(searchText)
+    }
 
     var body: some View {
         NavigationStack {
-            List {
-                Section("Server Setup") {
-                    Text("Server IP: Enter your Windows server’s IP address, e.g., '192.168.1.100'. Find it using 'ipconfig' in Command Prompt on the server.")
-                    Text("Share Name: Enter the name of the shared folder on your server, e.g., 'Images'. Set this up in Windows File Explorer under 'Share' settings.")
-                    Text("Target Directory: Optional - Specify a subfolder within the share for uploads, e.g., 'Uploads'. Ensure it exists or will be created by the server.")
-                    Text("Username and Password: Use your Windows credentials or a specific user account with access to the share. Contact your IT department if unsure.")
-                }
-                Section("Troubleshooting") {
-                    Text("Connection Issues: Ensure you’re on the same network as the server, the IP is correct, and the share is accessible. Test by connecting via Files app on iOS.")
-                    Text("Upload Failed: Verify all settings (IP, share name, directory, credentials) are complete in Settings. Missing details prevent uploads.")
-                }
-                Section("Onboarding") {
-                    Button("Revisit Onboarding") {
-                        onboardingCompleted = false
-                        dismiss()
+            BackgroundContainerView {
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 22) {
+                        HelpQuickActions(onReplayOnboarding: replayOnboarding)
+
+                        if searchText.isEmpty {
+                            HelpTopicGrid()
+                            FeaturedHelpSection()
+                        } else {
+                            HelpSearchResults(articles: searchResults, query: searchText)
+                        }
                     }
+                    .padding(20)
+                }
+                .scrollDismissesKeyboard(.interactively)
+            }
+            .navigationTitle("Help Center")
+            .navigationBarTitleDisplayMode(.large)
+            .searchable(text: $searchText, prompt: "Search help")
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done", action: dismiss.callAsFunction)
                 }
             }
-            .navigationTitle("Help Guide")
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button("Close") {
-                        dismiss()
+            .navigationDestination(for: HelpTopic.self) { topic in
+                HelpTopicView(topic: topic)
+            }
+            .navigationDestination(for: HelpArticle.self) { article in
+                HelpArticleView(article: article)
+            }
+        }
+    }
+
+    private func replayOnboarding() {
+        onboardingCompleted = false
+        dismiss()
+    }
+}
+
+enum HelpTopic: String, CaseIterable, Identifiable, Hashable {
+    case capture
+    case gallery
+    case upload
+    case archive
+    case privacy
+    case troubleshooting
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .capture: "Photos & Scanner"
+        case .gallery: "Gallery & PDF"
+        case .upload: "Upload & Server"
+        case .archive: "Archive & Files"
+        case .privacy: "Privacy & Storage"
+        case .troubleshooting: "Troubleshooting"
+        }
+    }
+
+    var summary: String {
+        switch self {
+        case .capture: "Capture photos and scan multi-page documents."
+        case .gallery: "Organize images and create PDFs."
+        case .upload: "Connect and upload to your SMB share."
+        case .archive: "Save, restore, rename, and delete archives."
+        case .privacy: "Understand local storage and image handling."
+        case .troubleshooting: "Resolve permissions, connection, and upload issues."
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .capture: "doc.viewfinder"
+        case .gallery: "doc.richtext.fill"
+        case .upload: "network"
+        case .archive: "archivebox.fill"
+        case .privacy: "hand.raised.fill"
+        case .troubleshooting: "wrench.and.screwdriver.fill"
+        }
+    }
+
+    var tint: Color {
+        switch self {
+        case .capture: .blue
+        case .gallery: .indigo
+        case .upload: .teal
+        case .archive: .orange
+        case .privacy: .purple
+        case .troubleshooting: .gray
+        }
+    }
+
+    var articles: [HelpArticle] {
+        HelpContent.articles.filter { $0.topic == self }
+    }
+}
+
+struct HelpArticle: Identifiable, Hashable {
+    let id: String
+    let topic: HelpTopic
+    let title: String
+    let summary: String
+    let keywords: [String]
+    let steps: [String]
+    let tip: String?
+    let warning: String?
+
+    var searchableText: String {
+        ([title, summary] + keywords + steps)
+            .joined(separator: " ")
+            .localizedLowercase
+    }
+}
+
+enum HelpContent {
+    static let articles: [HelpArticle] = [
+        HelpArticle(
+            id: "capture-photo",
+            topic: .capture,
+            title: "Capture a photo",
+            summary: "Take a photo, review it, and save it to the local Gallery.",
+            keywords: ["camera", "picture", "retake", "zoom"],
+            steps: [
+                "Tap Capture Image on Home.",
+                "Frame the subject and use the zoom controls if needed.",
+                "Tap the shutter button, then review the result.",
+                "Retake the photo or save it to Gallery."
+            ],
+            tip: "Landscape capture is supported. The saved image follows the device orientation.",
+            warning: nil
+        ),
+        HelpArticle(
+            id: "scan-document",
+            topic: .capture,
+            title: "Scan a multi-page document",
+            summary: "Use edge detection and auto-capture to collect document pages.",
+            keywords: ["scan", "document", "page", "auto capture", "edge detection"],
+            steps: [
+                "Tap Scan Documents on Home.",
+                "Hold the device over a page until its edges are detected.",
+                "Let auto-capture take the page, or use the shutter button manually.",
+                "Continue scanning until every page has been captured.",
+                "Review the pages and finish to save them in Gallery."
+            ],
+            tip: "Turn off Auto-capture in the scanner when you need precise manual timing.",
+            warning: nil
+        ),
+        HelpArticle(
+            id: "review-scan",
+            topic: .capture,
+            title: "Review, crop, and rotate scans",
+            summary: "Correct page boundaries and orientation before creating a PDF.",
+            keywords: ["crop", "rotate", "review", "retake", "orientation"],
+            steps: [
+                "Open the captured page in the scanner review flow.",
+                "Adjust the crop corners to match the document edges.",
+                "Rotate the page until text is upright.",
+                "Retake a page if focus or lighting is poor.",
+                "Confirm the page to keep the corrected result."
+            ],
+            tip: nil,
+            warning: "Check every page before combining scans into a PDF."
+        ),
+        HelpArticle(
+            id: "manage-gallery",
+            topic: .gallery,
+            title: "Organize Gallery items",
+            summary: "Select, rename, reorder, delete, archive, or upload local items.",
+            keywords: ["gallery", "rename", "select", "reorder", "delete", "batch"],
+            steps: [
+                "Open View Gallery from Home.",
+                "Select one or more items for batch actions.",
+                "Rename items individually or use the batch naming flow.",
+                "Reorder selected pages before creating a combined PDF.",
+                "Archive, upload, or delete items when ready."
+            ],
+            tip: "Use clear names before upload so files are easy to identify on the server.",
+            warning: nil
+        ),
+        HelpArticle(
+            id: "create-pdf",
+            topic: .gallery,
+            title: "Create and upload one PDF",
+            summary: "Combine selected Gallery images or scans into a single PDF.",
+            keywords: ["pdf", "combine", "single pdf", "pages", "compression"],
+            steps: [
+                "Select the images or scanned pages in Gallery.",
+                "Choose Single PDF as the output mode.",
+                "Arrange pages in the required order and enter a file name.",
+                "Create the PDF and review the upload screen.",
+                "Upload it now or keep the source pages in Gallery."
+            ],
+            tip: "PDF page size, image fit, page numbers, and compression are configured in Settings.",
+            warning: nil
+        ),
+        HelpArticle(
+            id: "pdf-settings",
+            topic: .gallery,
+            title: "Choose PDF output settings",
+            summary: "Control page size, image fit, page numbers, and compression.",
+            keywords: ["a4", "letter", "fit", "fill", "page number", "quality"],
+            steps: [
+                "Open Settings.",
+                "Find the PDF Output section.",
+                "Choose A4 or Letter page size.",
+                "Choose Fit Whole Image or Fill Page.",
+                "Set page numbers and compression for future PDFs."
+            ],
+            tip: "Fit Whole Image avoids cropping. Fill Page uses the full page but may crop edges.",
+            warning: nil
+        ),
+        HelpArticle(
+            id: "connect-server",
+            topic: .upload,
+            title: "Connect your SMB server",
+            summary: "Configure the local server used for image and PDF uploads.",
+            keywords: ["smb", "server", "share", "username", "password", "port", "settings"],
+            steps: [
+                "Open Settings and find Server Connection.",
+                "Enter your target directory, username, password, and optional port.",
+                "Browse the network for servers, try a direct IP, or switch to manual setup.",
+                "Confirm the server IP and share name.",
+                "Save the settings, then return to Home."
+            ],
+            tip: "The password is stored in the iOS Keychain. Other server settings are stored locally.",
+            warning: "Your device and SMB server must be reachable on the same local network."
+        ),
+        HelpArticle(
+            id: "upload-files",
+            topic: .upload,
+            title: "Upload images or PDFs",
+            summary: "Send Gallery items to the configured local network share.",
+            keywords: ["upload", "queue", "retry", "duplicate", "overwrite"],
+            steps: [
+                "Select files in Gallery, or open Upload to use the current queue.",
+                "Review file names and confirm that Server Connection is complete.",
+                "Start the upload and keep the app open while transfers are active.",
+                "Retry failed files or follow the displayed guidance.",
+                "For a duplicate name, rename the file or explicitly overwrite it."
+            ],
+            tip: "The free trial includes 15 successful uploads. Full App Unlock removes that limit.",
+            warning: "Do not leave the network while an upload is active."
+        ),
+        HelpArticle(
+            id: "manage-archives",
+            topic: .archive,
+            title: "Archive and restore Gallery items",
+            summary: "Move local images into dated archives and restore them later.",
+            keywords: ["archive", "restore", "date", "rename archive", "delete archive"],
+            steps: [
+                "Select Gallery items and choose Save to Archive.",
+                "Open Archives from Home to view dated groups.",
+                "Rename an archive when a descriptive label is more useful than its date.",
+                "Select an archive to restore its files to Gallery.",
+                "Delete archives only after confirming their contents are no longer needed."
+            ],
+            tip: "Archives remain in the app's Documents folder on this device.",
+            warning: "Deleting an archive permanently removes its local files."
+        ),
+        HelpArticle(
+            id: "privacy-storage",
+            topic: .privacy,
+            title: "How ImageDropX handles your data",
+            summary: "Images, documents, settings, and credentials remain under your control.",
+            keywords: ["privacy", "local", "storage", "metadata", "keychain", "cloud"],
+            steps: [
+                "Captured images are stored locally in the app's Documents folder.",
+                "Archives are organized locally by date.",
+                "Uploads go only to the SMB destination you configure.",
+                "Passwords are stored in the iOS Keychain.",
+                "Use Strip Image Metadata Before Upload in Settings when metadata should be removed."
+            ],
+            tip: "ImageDropX includes no analytics, telemetry, or cloud synchronization.",
+            warning: nil
+        ),
+        HelpArticle(
+            id: "connection-troubleshooting",
+            topic: .troubleshooting,
+            title: "Server cannot be found",
+            summary: "Check network access, server details, and SMB permissions.",
+            keywords: ["connection", "network", "bonjour", "direct ip", "not found", "permission"],
+            steps: [
+                "Confirm the iPhone or iPad is connected to the same network as the server.",
+                "Allow Local Network access for ImageDropX in iOS Settings.",
+                "Try the server IP directly if discovery finds no results.",
+                "Verify the share name, username, password, and optional port.",
+                "Confirm the account can access the share from another device."
+            ],
+            tip: "The iOS Files app can help confirm whether the SMB server is reachable.",
+            warning: nil
+        ),
+        HelpArticle(
+            id: "upload-troubleshooting",
+            topic: .troubleshooting,
+            title: "An upload failed",
+            summary: "Use the failure message to correct settings, names, or access.",
+            keywords: ["failed", "error", "unreadable", "authentication", "duplicate"],
+            steps: [
+                "Open the failed item to read its reason and guidance.",
+                "Check Server Connection when authentication or destination details are incomplete.",
+                "Rename the file when the server already contains the same name.",
+                "Confirm the target directory exists and the account can write to it.",
+                "Retry only the failed items after correcting the issue."
+            ],
+            tip: nil,
+            warning: "Repeated authentication failures usually mean the username, password, or share permissions are incorrect."
+        )
+    ]
+
+    static func search(_ query: String) -> [HelpArticle] {
+        let terms = query
+            .localizedLowercase
+            .split(whereSeparator: \.isWhitespace)
+            .map(String.init)
+
+        guard !terms.isEmpty else { return articles }
+        return articles.filter { article in
+            terms.allSatisfy { article.searchableText.contains($0) }
+        }
+    }
+}
+
+private struct HelpQuickActions: View {
+    let onReplayOnboarding: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Quick Start")
+                .font(.headline)
+
+            AppGlassCard(tint: .blue) {
+                NavigationLink(value: HelpContent.articles.first { $0.id == "connect-server" }!) {
+                    HelpActionRow(
+                        systemImage: "network",
+                        tint: .blue,
+                        title: "Connect your server",
+                        subtitle: "Set up local SMB upload"
+                    )
+                }
+                .buttonStyle(.plain)
+
+                Divider()
+                    .padding(.vertical, 8)
+
+                Button(action: onReplayOnboarding) {
+                    HelpActionRow(
+                        systemImage: "play.fill",
+                        tint: .indigo,
+                        title: "Replay onboarding",
+                        subtitle: "Review the essentials"
+                    )
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+}
+
+private struct HelpActionRow: View {
+    let systemImage: String
+    let tint: Color
+    let title: String
+    let subtitle: String
+
+    var body: some View {
+        HStack(spacing: 13) {
+            Image(systemName: systemImage)
+                .font(.headline)
+                .foregroundStyle(.white)
+                .frame(width: 42, height: 42)
+                .background(tint.gradient, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(title)
+                    .font(.headline)
+                    .foregroundStyle(.primary)
+                Text(subtitle)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+            Image(systemName: "chevron.right")
+                .font(.caption.bold())
+                .foregroundStyle(.tertiary)
+        }
+        .contentShape(Rectangle())
+    }
+}
+
+private struct HelpTopicGrid: View {
+    private let columns = [
+        GridItem(.flexible(), spacing: 12),
+        GridItem(.flexible(), spacing: 12)
+    ]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Browse Topics")
+                .font(.headline)
+
+            GlassEffectContainer(spacing: 12) {
+                LazyVGrid(columns: columns, spacing: 12) {
+                    ForEach(HelpTopic.allCases) { topic in
+                        NavigationLink(value: topic) {
+                            HelpTopicCard(topic: topic)
+                        }
+                        .buttonStyle(.plain)
                     }
                 }
             }
         }
     }
+}
+
+private struct HelpTopicCard: View {
+    let topic: HelpTopic
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Image(systemName: topic.systemImage)
+                .font(.title2.weight(.semibold))
+                .foregroundStyle(topic.tint)
+            Text(topic.title)
+                .font(.headline)
+                .foregroundStyle(.primary)
+                .multilineTextAlignment(.leading)
+            Text(topic.articles.count == 1 ? "1 guide" : "\(topic.articles.count) guides")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, minHeight: 116, alignment: .leading)
+        .padding(16)
+        .glassEffect(.regular.interactive(), in: .rect(cornerRadius: 22))
+        .contentShape(.rect(cornerRadius: 22))
+    }
+}
+
+private struct FeaturedHelpSection: View {
+    private let articleIDs = ["scan-document", "create-pdf", "connection-troubleshooting"]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Popular Guides")
+                .font(.headline)
+
+            AppGlassCard {
+                ForEach(Array(featuredArticles.enumerated()), id: \.element.id) { index, article in
+                    NavigationLink(value: article) {
+                        HelpArticleRow(article: article)
+                    }
+                    .buttonStyle(.plain)
+
+                    if index < featuredArticles.count - 1 {
+                        Divider()
+                            .padding(.leading, 48)
+                    }
+                }
+            }
+        }
+    }
+
+    private var featuredArticles: [HelpArticle] {
+        articleIDs.compactMap { id in HelpContent.articles.first { $0.id == id } }
+    }
+}
+
+private struct HelpSearchResults: View {
+    let articles: [HelpArticle]
+    let query: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Search Results")
+                .font(.headline)
+
+            if articles.isEmpty {
+                ContentUnavailableView.search(text: query)
+                    .frame(maxWidth: .infinity)
+                    .padding(.top, 50)
+            } else {
+                AppGlassCard {
+                    ForEach(Array(articles.enumerated()), id: \.element.id) { index, article in
+                        NavigationLink(value: article) {
+                            HelpArticleRow(article: article)
+                        }
+                        .buttonStyle(.plain)
+
+                        if index < articles.count - 1 {
+                            Divider()
+                                .padding(.leading, 48)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+private struct HelpArticleRow: View {
+    let article: HelpArticle
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: article.topic.systemImage)
+                .foregroundStyle(article.topic.tint)
+                .frame(width: 36, height: 36)
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(article.title)
+                    .font(.headline)
+                    .foregroundStyle(.primary)
+                Text(article.summary)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+            }
+
+            Spacer()
+            Image(systemName: "chevron.right")
+                .font(.caption.bold())
+                .foregroundStyle(.tertiary)
+        }
+        .padding(.vertical, 8)
+        .contentShape(Rectangle())
+    }
+}
+
+private struct HelpTopicView: View {
+    let topic: HelpTopic
+
+    var body: some View {
+        BackgroundContainerView {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 18) {
+                    AppSymbolTile(systemImage: topic.systemImage, tint: topic.tint)
+
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text(topic.title)
+                            .font(.largeTitle.bold())
+                        Text(topic.summary)
+                            .font(.body)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    AppGlassCard(tint: topic.tint) {
+                        ForEach(Array(topic.articles.enumerated()), id: \.element.id) { index, article in
+                            NavigationLink(value: article) {
+                                HelpArticleRow(article: article)
+                            }
+                            .buttonStyle(.plain)
+
+                            if index < topic.articles.count - 1 {
+                                Divider()
+                                    .padding(.leading, 48)
+                            }
+                        }
+                    }
+                }
+                .padding(20)
+            }
+        }
+        .navigationTitle(topic.title)
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+private struct HelpArticleView: View {
+    let article: HelpArticle
+
+    var body: some View {
+        BackgroundContainerView {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 22) {
+                    AppSymbolTile(systemImage: article.topic.systemImage, tint: article.topic.tint)
+
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text(article.title)
+                            .font(.largeTitle.bold())
+                        Text(article.summary)
+                            .font(.body)
+                            .foregroundStyle(.secondary)
+                            .lineSpacing(3)
+                    }
+
+                    AppGlassCard(tint: article.topic.tint) {
+                        VStack(alignment: .leading, spacing: 18) {
+                            ForEach(Array(article.steps.enumerated()), id: \.offset) { index, step in
+                                HelpStepRow(number: index + 1, text: step, tint: article.topic.tint)
+                            }
+                        }
+                    }
+
+                    if let tip = article.tip {
+                        HelpCallout(title: "Tip", systemImage: "lightbulb.fill", text: tip, tint: .blue)
+                    }
+
+                    if let warning = article.warning {
+                        HelpCallout(title: "Important", systemImage: "exclamationmark.triangle.fill", text: warning, tint: .orange)
+                    }
+                }
+                .padding(20)
+            }
+        }
+        .navigationTitle(article.topic.title)
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+private struct HelpStepRow: View {
+    let number: Int
+    let text: String
+    let tint: Color
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 13) {
+            Text("\(number)")
+                .font(.subheadline.bold())
+                .foregroundStyle(.white)
+                .frame(width: 30, height: 30)
+                .background(tint.gradient, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+                .accessibilityHidden(true)
+
+            Text(text)
+                .font(.body)
+                .foregroundStyle(.primary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Step \(number). \(text)")
+    }
+}
+
+private struct HelpCallout: View {
+    let title: String
+    let systemImage: String
+    let text: String
+    let tint: Color
+
+    var body: some View {
+        AppGlassCard(tint: tint) {
+            HStack(alignment: .top, spacing: 12) {
+                Image(systemName: systemImage)
+                    .foregroundStyle(tint)
+                    .font(.headline)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(title)
+                        .font(.headline)
+                    Text(text)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    HelpGuideView()
 }

--- a/LANImageUploader/HelpGuideView.swift
+++ b/LANImageUploader/HelpGuideView.swift
@@ -348,15 +348,17 @@ private struct HelpQuickActions: View {
                 .font(.headline)
 
             AppGlassCard(tint: .blue) {
-                NavigationLink(value: HelpContent.articles.first { $0.id == "connect-server" }!) {
-                    HelpActionRow(
-                        systemImage: "network",
-                        tint: .blue,
-                        title: "Connect your server",
-                        subtitle: "Set up local SMB upload"
-                    )
+                if let connectServerArticle = HelpContent.articles.first(where: { $0.id == "connect-server" }) {
+                    NavigationLink(value: connectServerArticle) {
+                        HelpActionRow(
+                            systemImage: "network",
+                            tint: .blue,
+                            title: "Connect your server",
+                            subtitle: "Set up local SMB upload"
+                        )
+                    }
+                    .buttonStyle(.plain)
                 }
-                .buttonStyle(.plain)
 
                 Divider()
                     .padding(.vertical, 8)

--- a/LANImageUploader/HomeView.swift
+++ b/LANImageUploader/HomeView.swift
@@ -2,156 +2,252 @@
 //  HomeView.swift
 //  LANImageUploader
 //
-//  Created by Jan Hagen Clausen on 21/02/2025.
-//
 
 import SwiftUI
 
-struct TransparentNavigationBar: ViewModifier {
-    func body(content: Content) -> some View {
-        content
-            .toolbarColorScheme(.dark, for: .navigationBar)
-            .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
-            .navigationBarTitleDisplayMode(.large)
-    }
-}
-
-extension View {
-    func withTransparentNavigationBar() -> some View {
-        self.modifier(TransparentNavigationBar())
-    }
-}
-
 struct HomeView: View {
-    @EnvironmentObject var appData: AppData
-    @State private var hasAppeared = false
+    @EnvironmentObject private var appData: AppData
     @State private var activeCameraMode: CameraCaptureMode?
-    @Environment(\.colorScheme) private var colorScheme
-    
-    var areSettingsComplete: Bool {
-        !appData.settings.serverIP.isEmpty && !appData.settings.shareName.isEmpty
-            && !appData.settings.username.isEmpty && appData.getPassword() != nil
+
+    private var isServerConnectionComplete: Bool {
+        ServerConnectionReadiness.isComplete(
+            settings: appData.settings,
+            password: appData.getPassword()
+        )
     }
 
     var body: some View {
         NavigationStack {
-            Color.clear
-                .ignoresSafeArea()
-                .background(
-                    LinearGradient(
-                        gradient: Gradient(colors: [
-                            colorScheme == .dark ? Color(uiColor: .systemGray2) : Color.white,
-                            colorScheme == .dark ? Color.black : Color(uiColor: .systemGray3)
-                        ]),
-                        startPoint: .top,
-                        endPoint: .bottom
-                    )
-                    .ignoresSafeArea()
-                )
-                .overlay(
-                    VStack {
-                        Spacer()
-                        
-                        VStack(spacing: 20) {
-                            Button {
-                                activeCameraMode = .photo
-                            } label: {
-                                Label("Capture Image", systemImage: "camera")
-                                    .frame(maxWidth: .infinity)
-                                    .padding()
-                                    .background(Color.blue)
-                                    .foregroundColor(.white)
-                                    .clipShape(RoundedRectangle(cornerRadius: 8))
-                            }
+            BackgroundContainerView {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 22) {
+                        HomeHeader()
 
-                            Button {
-                                activeCameraMode = .scan
-                            } label: {
-                                Label("Scan Documents", systemImage: "doc.viewfinder")
-                                    .frame(maxWidth: .infinity)
-                                    .padding()
-                                    .background(Color.indigo)
-                                    .foregroundColor(.white)
-                                    .clipShape(RoundedRectangle(cornerRadius: 8))
-                            }
-
-                            NavigationLink(destination: GalleryView()) {
-                                Label("View Gallery", systemImage: "photo.on.rectangle")
-                                    .frame(maxWidth: .infinity)
-                                    .padding()
-                                    .background(Color.green)
-                                    .foregroundColor(.white)
-                                    .clipShape(RoundedRectangle(cornerRadius: 8))
-                            }
-                            
-                            NavigationLink(destination: UploadView()) {
-                                Label("Upload", systemImage: "arrow.up.circle")
-                                    .frame(maxWidth: .infinity)
-                                    .padding()
-                                    .background(Color.orange)
-                                    .foregroundColor(.white)
-                                    .clipShape(RoundedRectangle(cornerRadius: 8))
-                            }
-                            
-                            NavigationLink(destination: SettingsView()) {
-                                Label("Settings", systemImage: "gear")
-                                    .frame(maxWidth: .infinity)
-                                    .padding()
-                                    .background(Color.gray)
-                                    .foregroundColor(.white)
-                                    .clipShape(RoundedRectangle(cornerRadius: 8))
-                            }
-                            .badge(areSettingsComplete ? nil : "!")
-                            .badgeProminence(.increased)
-                            
-                            NavigationLink(destination: ArchiveView()) {
-                                Label("Archives", systemImage: "archivebox")
-                                    .frame(maxWidth: .infinity)
-                                    .padding()
-                                    .background(Color.purple)
-                                    .foregroundColor(.white)
-                                    .clipShape(RoundedRectangle(cornerRadius: 8))
-                            }
+                        if !isServerConnectionComplete {
+                            ServerSetupCard()
+                                .transition(.move(edge: .top).combined(with: .opacity))
                         }
-                        .padding(.horizontal)
-                        
-                        Spacer()
+
+                        HomeCaptureActions(activeCameraMode: $activeCameraMode)
+                        HomeLibraryActions()
                     }
-                )
-                .navigationTitle("ImageDropX")
-                .toolbarColorScheme(colorScheme, for: .navigationBar)
-                .toolbarBackground(.hidden, for: .navigationBar)
-                .fullScreenCover(item: $activeCameraMode) { mode in
-                    CameraView(initialMode: mode)
-                        .environmentObject(appData)
+                    .padding(20)
                 }
+            }
+            .navigationTitle("ImageDropX")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbarBackground(.hidden, for: .navigationBar)
+            .fullScreenCover(item: $activeCameraMode) { mode in
+                CameraView(initialMode: mode)
+                    .environmentObject(appData)
+            }
+            .animation(.snappy, value: isServerConnectionComplete)
         }
-        .onAppear {
-            if !hasAppeared {
-                DispatchQueue.main.async {
-                    if #available(iOS 15.0, *) {
-                        let appearance = UINavigationBarAppearance()
-                        appearance.configureWithTransparentBackground()
-                        appearance.backgroundColor = UIColor.clear
-                        appearance.shadowColor = nil
-                        
-                        let textColor = colorScheme == .dark ? UIColor.white : UIColor.black
-                        appearance.titleTextAttributes = [.foregroundColor: textColor]
-                        appearance.largeTitleTextAttributes = [.foregroundColor: textColor]
-                        
-                        UINavigationBar.appearance().standardAppearance = appearance
-                        UINavigationBar.appearance().compactAppearance = appearance
-                        UINavigationBar.appearance().scrollEdgeAppearance = appearance
-                    } else {
-                        UINavigationBar.appearance().setBackgroundImage(UIImage(), for: .default)
-                        UINavigationBar.appearance().shadowImage = UIImage()
-                        UINavigationBar.appearance().isTranslucent = true
-                        UINavigationBar.appearance().backgroundColor = .clear
+    }
+}
+
+enum ServerConnectionReadiness {
+    static func isComplete(settings: ServerSettings, password: String?) -> Bool {
+        !settings.serverIP.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
+        !settings.shareName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
+        !settings.username.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
+        !(password?.isEmpty ?? true)
+    }
+}
+
+private struct HomeHeader: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Capture. Organize. Upload.")
+                .font(.largeTitle.bold())
+            Text("Photos and documents stay on this device until you send them to your local server.")
+                .font(.body)
+                .foregroundStyle(.secondary)
+                .lineSpacing(3)
+        }
+        .accessibilityElement(children: .combine)
+    }
+}
+
+private struct ServerSetupCard: View {
+    var body: some View {
+        AppGlassCard(tint: .blue) {
+            VStack(alignment: .leading, spacing: 16) {
+                HStack(spacing: 14) {
+                    AppSymbolTile(systemImage: "network", tint: .blue, size: 56)
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Get upload ready")
+                            .font(.title3.bold())
+                        Text("Connect your local SMB server. Capture and scanning already work without it.")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
                     }
-                    hasAppeared = true
+                }
+
+                NavigationLink {
+                    SettingsView()
+                } label: {
+                    FullWidthGlassButtonLabel("Open Server Connection", systemImage: "arrow.right")
+                }
+                .buttonStyle(.glassProminent)
+
+                Label("Settings > Server Connection", systemImage: "gearshape")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .center)
+            }
+        }
+        .accessibilityIdentifier("server-setup-card")
+    }
+}
+
+private struct HomeCaptureActions: View {
+    @Binding var activeCameraMode: CameraCaptureMode?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Create")
+                .font(.headline)
+
+            GlassEffectContainer(spacing: 12) {
+                HStack(spacing: 12) {
+                    HomeActionButton(
+                        title: "Capture Image",
+                        subtitle: "Take a photo",
+                        systemImage: "camera.fill",
+                        tint: .blue
+                    ) {
+                        activeCameraMode = .photo
+                    }
+
+                    HomeActionButton(
+                        title: "Scan Documents",
+                        subtitle: "Multi-page scan",
+                        systemImage: "doc.viewfinder",
+                        tint: .indigo
+                    ) {
+                        activeCameraMode = .scan
+                    }
                 }
             }
         }
+    }
+}
+
+private struct HomeLibraryActions: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Library & Transfer")
+                .font(.headline)
+
+            GlassEffectContainer(spacing: 12) {
+                LazyVGrid(
+                    columns: [
+                        GridItem(.flexible(), spacing: 12),
+                        GridItem(.flexible(), spacing: 12)
+                    ],
+                    spacing: 12
+                ) {
+                    NavigationLink {
+                        GalleryView()
+                    } label: {
+                        HomeActionCard(
+                            title: "Gallery",
+                            subtitle: "Organize & create PDF",
+                            systemImage: "photo.stack.fill",
+                            tint: .green
+                        )
+                    }
+
+                    NavigationLink {
+                        UploadView()
+                    } label: {
+                        HomeActionCard(
+                            title: "Upload",
+                            subtitle: "Send queued files",
+                            systemImage: "arrow.up.circle.fill",
+                            tint: .orange
+                        )
+                    }
+
+                    NavigationLink {
+                        ArchiveView()
+                    } label: {
+                        HomeActionCard(
+                            title: "Archives",
+                            subtitle: "Restore saved work",
+                            systemImage: "archivebox.fill",
+                            tint: .purple
+                        )
+                    }
+
+                    NavigationLink {
+                        SettingsView()
+                    } label: {
+                        HomeActionCard(
+                            title: "Settings",
+                            subtitle: "Server, PDF & privacy",
+                            systemImage: "gearshape.fill",
+                            tint: .gray
+                        )
+                    }
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+}
+
+private struct HomeActionButton: View {
+    let title: String
+    let subtitle: String
+    let systemImage: String
+    let tint: Color
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HomeActionCard(
+                title: title,
+                subtitle: subtitle,
+                systemImage: systemImage,
+                tint: tint
+            )
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+private struct HomeActionCard: View {
+    let title: String
+    let subtitle: String
+    let systemImage: String
+    let tint: Color
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Image(systemName: systemImage)
+                .font(.title2.weight(.semibold))
+                .foregroundStyle(tint)
+                .frame(width: 40, height: 40)
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(title)
+                    .font(.headline)
+                    .foregroundStyle(.primary)
+                Text(subtitle)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.leading)
+                    .lineLimit(2)
+            }
+        }
+        .frame(maxWidth: .infinity, minHeight: 124, alignment: .leading)
+        .padding(16)
+        .glassEffect(.regular.tint(tint.opacity(0.1)).interactive(), in: .rect(cornerRadius: 22))
+        .contentShape(.rect(cornerRadius: 22))
     }
 }
 

--- a/LANImageUploader/OnboardingView.swift
+++ b/LANImageUploader/OnboardingView.swift
@@ -2,660 +2,283 @@
 //  OnboardingView.swift
 //  LANImageUploader
 //
-//  Created by Jan Hagen Clausen on 22/02/2025.
-//
 
 import SwiftUI
-import AMSMB2
-import Network
 
 public struct OnboardingView: View {
-    @EnvironmentObject var appData: AppData
-    @AppStorage("onboardingCompleted") var onboardingCompleted: Bool = false
-    @State private var currentStep = 0
-    @State private var showHelpGuide = false
-    @State private var showNetworkSetup = false
+    @AppStorage(Constants.UserDefaults.onboardingCompleted) private var onboardingCompleted = false
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var selectedPage = 0
 
-    private let steps: [OnboardingStep] = [
-        .welcome, .features, .settings, .tutorial, .helpGuide, .completion
-    ]
+    private let pages = OnboardingPage.allCases
 
     public var body: some View {
         BackgroundContainerView {
-            NavigationStack {
-                VStack {
-                    switch steps[currentStep] {
-                    case .welcome:
-                        WelcomePage(nextAction: nextStep)
-                    case .features:
-                        FeaturesPage(nextAction: nextStep)
-                    case .settings:
-                        if showNetworkSetup {
-                            NetworkSetupView(nextAction: nextStep)
-                                .environmentObject(appData)
-                        } else {
-                            OnboardingSettingsView(nextAction: nextStep)
-                                .environmentObject(appData)
-                        }
-                    case .tutorial:
-                        TutorialPage(nextAction: nextStep)
-                    case .helpGuide:
-                        HelpGuideIntroPage(nextAction: nextStep, showHelpGuide: $showHelpGuide)
-                    case .completion:
-                        CompletionPage(completeAction: completeOnboarding)
+            VStack(spacing: 0) {
+                OnboardingHeader(
+                    currentPage: selectedPage,
+                    pageCount: pages.count,
+                    onSkip: completeOnboarding
+                )
+
+                TabView(selection: $selectedPage) {
+                    ForEach(Array(pages.enumerated()), id: \.element) { index, page in
+                        OnboardingPageView(page: page)
+                            .tag(index)
                     }
                 }
-                .navigationBarHidden(true)
-                .background(Color.clear)
-                .scrollContentBackground(.hidden)
-                .sheet(isPresented: $showHelpGuide) {
-                    HelpGuideView()
-                }
-                .onChange(of: currentStep) { _, newStep in
-                    if steps[newStep] == .settings {
-                        checkSettings()
-                    }
-                }
+                .tabViewStyle(.page(indexDisplayMode: .never))
+                .animation(reduceMotion ? nil : .snappy, value: selectedPage)
+
+                OnboardingFooter(
+                    isFirstPage: selectedPage == 0,
+                    isLastPage: selectedPage == pages.count - 1,
+                    onBack: previousPage,
+                    onContinue: advance
+                )
             }
+            .padding(.horizontal, 20)
+            .padding(.vertical, 12)
         }
     }
 
-    func nextStep() {
-        if currentStep < steps.count - 1 {
-            currentStep += 1
+    private func previousPage() {
+        guard selectedPage > 0 else { return }
+        withAnimation(reduceMotion ? nil : .snappy) {
+            selectedPage -= 1
         }
     }
 
-    func completeOnboarding() {
+    private func advance() {
+        guard selectedPage < pages.count - 1 else {
+            completeOnboarding()
+            return
+        }
+        withAnimation(reduceMotion ? nil : .snappy) {
+            selectedPage += 1
+        }
+    }
+
+    private func completeOnboarding() {
         onboardingCompleted = true
     }
-
-    private func checkSettings() {
-        let settings = appData.settings
-        let password = appData.getPassword()
-        showNetworkSetup = settings.serverIP.isEmpty || settings.shareName.isEmpty ||
-                           (settings.targetDirectory?.isEmpty ?? true) || settings.username.isEmpty ||
-                           password == nil
-    }
 }
 
-public enum OnboardingStep {
-    case welcome, features, settings, tutorial, helpGuide, completion
-}
+enum OnboardingPage: String, CaseIterable {
+    case privacy
+    case capture
+    case organize
+    case ready
 
-struct WelcomePage: View {
-    let nextAction: () -> Void
-
-    var body: some View {
-        VStack(spacing: 20) {
-            Spacer()
-            Text("Welcome to ImageDropX!")
-                .font(.largeTitle)
-                .fontWeight(.bold)
-            Text("A simple and secure tool to capture images and upload them directly to your local network share.")
-                .font(.body)
-                .multilineTextAlignment(.center)
-                .padding(.horizontal)
-            Text("Copyright © 2025 Jan H. Clausen, Midtbylægerne")
-                .font(.footnote)
-                .foregroundStyle(.gray)
-            Spacer()
-            Button("Get Started") {
-                nextAction()
-            }
-            .frame(maxWidth: .infinity)
-            .padding()
-            .background(Color.blue)
-            .foregroundStyle(.white)
-            .clipShape(RoundedRectangle(cornerRadius: 10))
-            .padding(.horizontal)
+    var title: String {
+        switch self {
+        case .privacy: "Capture anything. Keep it private."
+        case .capture: "Photo or document"
+        case .organize: "Your gallery, your workflow"
+        case .ready: "You're ready"
         }
-        .padding(.vertical)
     }
-}
 
-struct FeaturesPage: View {
-    let nextAction: () -> Void
-
-    var body: some View {
-        VStack(spacing: 20) {
-            Spacer()
-            Text("Key Features")
-                .font(.title)
-                .fontWeight(.bold)
-            VStack(alignment: .center, spacing: 20) {
-                FeatureItem(icon: "camera.fill", title: "Capture Images", description: "Take high-quality photos with your device camera.")
-                FeatureItem(icon: "photo.on.rectangle", title: "Manage Gallery", description: "View and organize your captured images.")
-                FeatureItem(icon: "arrow.up.circle", title: "Upload Securely", description: "Send images to your local network share for storage.")
-            }
-            .padding(.horizontal, 30)
-            .frame(maxWidth: 500)
-            Spacer()
-            Button("Next") {
-                nextAction()
-            }
-            .frame(maxWidth: 300)
-            .padding()
-            .background(Color.blue)
-            .foregroundStyle(.white)
-            .clipShape(RoundedRectangle(cornerRadius: 10))
-            .padding(.horizontal)
+    var message: String {
+        switch self {
+        case .privacy:
+            "Photos and documents stay on your device until you choose to upload them to your local server."
+        case .capture:
+            "Take a photo, or scan multi-page documents with edge detection, auto-capture, crop, and rotation."
+        case .organize:
+            "Rename, reorder, archive, or combine selected images into one optimized PDF."
+        case .ready:
+            "Start capturing now. To upload, connect your SMB server from Settings."
         }
-        .padding(.vertical, 40)
+    }
+
+    var systemImage: String {
+        switch self {
+        case .privacy: "lock.shield.fill"
+        case .capture: "doc.viewfinder"
+        case .organize: "photo.stack.fill"
+        case .ready: "checkmark"
+        }
+    }
+
+    var tint: Color {
+        switch self {
+        case .privacy: .blue
+        case .capture: .indigo
+        case .organize: .teal
+        case .ready: .green
+        }
+    }
+
+    var detailItems: [OnboardingDetailItem] {
+        switch self {
+        case .privacy:
+            [
+                OnboardingDetailItem(icon: "iphone", title: "On-device by default", detail: "Your gallery and archives remain local."),
+                OnboardingDetailItem(icon: "network", title: "Your network, your server", detail: "Uploads go only to the SMB share you configure.")
+            ]
+        case .capture:
+            [
+                OnboardingDetailItem(icon: "camera.fill", title: "Capture photos", detail: "Take, review, and retake high-quality images."),
+                OnboardingDetailItem(icon: "rectangle.stack.fill", title: "Scan documents", detail: "Capture several pages in portrait or landscape.")
+            ]
+        case .organize:
+            [
+                OnboardingDetailItem(icon: "doc.richtext.fill", title: "Create PDFs", detail: "Choose page size, layout, page numbers, and compression."),
+                OnboardingDetailItem(icon: "archivebox.fill", title: "Keep work organized", detail: "Rename items and restore them from dated archives.")
+            ]
+        case .ready:
+            [
+                OnboardingDetailItem(icon: "gearshape.fill", title: "Settings > Server Connection", detail: "Add your server, share, username, and password."),
+                OnboardingDetailItem(icon: "house.fill", title: "Follow the Home setup card", detail: "It remains visible until upload is ready.")
+            ]
+        }
     }
 }
 
-struct FeatureItem: View {
+struct OnboardingDetailItem: Identifiable {
     let icon: String
     let title: String
-    let description: String
+    let detail: String
+
+    var id: String { title }
+}
+
+private struct OnboardingHeader: View {
+    let currentPage: Int
+    let pageCount: Int
+    let onSkip: () -> Void
 
     var body: some View {
-        HStack(spacing: 20) {
-            Image(systemName: icon)
-                .font(.title2)
-                .foregroundStyle(.blue)
-            VStack(alignment: .leading, spacing: 5) {
-                Text(title)
-                    .font(.headline)
-                Text(description)
-                    .font(.subheadline)
-                    .foregroundStyle(.gray)
-                    .lineLimit(2)
-            }
+        HStack(spacing: 16) {
+            OnboardingProgress(currentPage: currentPage, pageCount: pageCount)
             Spacer()
+            Button("Skip", action: onSkip)
+                .buttonStyle(.glass)
+                .accessibilityHint("Closes onboarding and opens the app")
         }
-        .padding(.vertical, 10)
+        .frame(minHeight: 48)
     }
 }
 
-struct OnboardingSettingsView: View {
-    @EnvironmentObject var appData: AppData
-    let nextAction: () -> Void
-    @AppStorage(Constants.UserDefaults.ocrMode) private var ocrModeRawValue: String = OCRMode.full.rawValue
-    @State private var serverIP = ""
-    @State private var shareName = ""
-    @State private var targetDirectory = ""
-    @State private var username = ""
-    @State private var password = ""
-    @State private var showWarning = false
-    @State private var port = ""
-
-    var areSettingsComplete: Bool {
-        !serverIP.isEmpty && !shareName.isEmpty && !targetDirectory.isEmpty && !username.isEmpty && !password.isEmpty
-    }
-    
-    private var ocrModeBinding: Binding<OCRMode> {
-        Binding(
-            get: { OCRMode(rawValue: ocrModeRawValue) ?? .full },
-            set: { ocrModeRawValue = $0.rawValue }
-        )
-    }
+private struct OnboardingProgress: View {
+    let currentPage: Int
+    let pageCount: Int
 
     var body: some View {
-        VStack(spacing: 20) {
-            Spacer()
-            Text("Set Up Your Server")
-                .font(.title)
-                .fontWeight(.bold)
-            Text("Enter your server details to enable image uploads (recommended). You can skip this and set it up later in Settings.")
-                .font(.subheadline)
-                .multilineTextAlignment(.center)
-                .foregroundStyle(.gray)
-                .padding(.horizontal)
-            Form {
-                TextField("Server IP (e.g., 192.168.1.100)", text: $serverIP)
-                    .textContentType(.URL)
-                    .keyboardType(.numbersAndPunctuation)
-                    .autocapitalization(.none)
-                TextField("", text: $port)
-                    .keyboardType(.numberPad)
-                    .placeholder(when: port.isEmpty) {
-                        Text("Port (optional)")
-                            .foregroundStyle(.gray)
-                    }
-                TextField("Share Name (e.g., Images)", text: $shareName)
-                    .autocapitalization(.none)
-                TextField("Target Directory (e.g., Uploads)", text: $targetDirectory)
-                    .autocapitalization(.none)
-                TextField("Username", text: $username)
-                    .textContentType(.username)
-                SecureField("Password", text: $password)
-                    .textContentType(.password)
-                Section("OCR") {
-                    Picker("OCR Mode", selection: ocrModeBinding) {
-                        ForEach(OCRMode.allCases) { mode in
-                            Text(mode.displayName).tag(mode)
+        HStack(spacing: 7) {
+            ForEach(0..<pageCount, id: \.self) { index in
+                Capsule()
+                    .fill(index == currentPage ? Color.accentColor : Color.secondary.opacity(0.28))
+                    .frame(width: index == currentPage ? 28 : 8, height: 8)
+            }
+        }
+        .animation(.snappy, value: currentPage)
+        .accessibilityElement()
+        .accessibilityLabel("Onboarding progress")
+        .accessibilityValue("Page \(currentPage + 1) of \(pageCount)")
+    }
+}
+
+private struct OnboardingPageView: View {
+    let page: OnboardingPage
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 26) {
+                Spacer(minLength: 16)
+
+                AppSymbolTile(systemImage: page.systemImage, tint: page.tint, size: 104)
+
+                VStack(spacing: 12) {
+                    Text(page.title)
+                        .font(.largeTitle.bold())
+                        .multilineTextAlignment(.center)
+                        .foregroundStyle(.primary)
+
+                    Text(page.message)
+                        .font(.body)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                        .lineSpacing(3)
+                }
+                .frame(maxWidth: 560)
+
+                GlassEffectContainer(spacing: 14) {
+                    VStack(spacing: 14) {
+                        ForEach(page.detailItems) { item in
+                            OnboardingDetailRow(item: item, tint: page.tint)
                         }
                     }
-                    .pickerStyle(.segmented)
                 }
-            }
-            .frame(maxHeight: 260)
-            Button("Save and Next") {
-                saveSettings()
-                nextAction()
+                .frame(maxWidth: 560)
+
+                Spacer(minLength: 20)
             }
             .frame(maxWidth: .infinity)
-            .padding()
-            .background(Color.blue)
-            .foregroundStyle(.white)
-            .clipShape(RoundedRectangle(cornerRadius: 10))
-            .padding(.horizontal)
-            Button("Skip") {
-                if !areSettingsComplete {
-                    showWarning = true
-                } else {
-                    nextAction()
-                }
-            }
-            .foregroundStyle(.gray)
-            Spacer()
+            .padding(.vertical, 12)
         }
-        .alert("Settings Incomplete", isPresented: $showWarning) {
-            Button("Set Up Now", role: .cancel) {}
-            Button("Skip Anyway") { nextAction() }
-        } message: {
-            Text("Uploads won't work without server details. Please set them up in Settings later if you skip now.")
-        }
-    }
-
-    func saveSettings() {
-            // Validate port if provided
-            let portNumber: Int?
-            if !port.isEmpty {
-                guard let number = Int(port), number > 0, number <= 65535 else {
-                    return
-                }
-                portNumber = number
-            } else {
-                portNumber = nil
-            }
-            
-            appData.settings = ServerSettings(
-                serverIP: serverIP,
-                shareName: shareName,
-                targetDirectory: targetDirectory,
-                username: username,
-                port: portNumber  // Add port to settings
-            )
-            try? appData.savePassword(password)
-        }
-}
-
-struct TutorialPage: View {
-    let nextAction: () -> Void
-
-    var body: some View {
-        VStack(spacing: 20) {
-            Spacer()
-            Text("How to Use ImageDropX")
-                .font(.title)
-                .fontWeight(.bold)
-            VStack(spacing: 20) {
-                StepItem(number: 1, text: "Tap 'Take Photo' to capture an image.", imageName: "capture_screen")
-                StepItem(number: 2, text: "View and rename images in the gallery.", imageName: "gallery_screen")
-                StepItem(number: 3, text: "Upload images to your server (settings required).", imageName: "upload_screen")
-            }
-            .padding(.horizontal, 10)
-            Spacer()
-            Button("Next") {
-                nextAction()
-            }
-            .frame(maxWidth: .infinity)
-            .padding()
-            .background(Color.blue)
-            .foregroundStyle(.white)
-            .clipShape(RoundedRectangle(cornerRadius: 10))
-            .padding(.horizontal)
-        }
-        .padding(.vertical)
+        .scrollIndicators(.hidden)
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("onboarding-\(page.rawValue)")
     }
 }
 
-struct StepItem: View {
-    let number: Int
-    let text: String
-    let imageName: String
+private struct OnboardingDetailRow: View {
+    let item: OnboardingDetailItem
+    let tint: Color
 
     var body: some View {
-        HStack(spacing: 15) {
-            Image(imageName)
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .frame(maxWidth: .infinity, maxHeight: 150)
-                .clipShape(RoundedRectangle(cornerRadius: 12))
-                .shadow(color: Color.black.opacity(0.1), radius: 4, x: 0, y: 2)
-                .onAppear {
-                    print("Loading image: \(imageName) – Found: \(UIImage(named: imageName) != nil)")
+        AppGlassCard(tint: tint) {
+            HStack(spacing: 14) {
+                Image(systemName: item.icon)
+                    .font(.title3.weight(.semibold))
+                    .foregroundStyle(tint)
+                    .frame(width: 36, height: 36)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(item.title)
+                        .font(.headline)
+                    Text(item.detail)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
                 }
-                .overlay(
-                    Text("Image not found: \(imageName)")
-                        .foregroundStyle(.red)
-                        .opacity(UIImage(named: imageName) == nil ? 1 : 0)
+            }
+        }
+    }
+}
+
+private struct OnboardingFooter: View {
+    let isFirstPage: Bool
+    let isLastPage: Bool
+    let onBack: () -> Void
+    let onContinue: () -> Void
+
+    var body: some View {
+        HStack(spacing: 12) {
+            if !isFirstPage {
+                Button(action: onBack) {
+                    Image(systemName: "chevron.left")
+                        .font(.headline)
+                        .frame(width: 44, height: 44)
+                }
+                .buttonStyle(.glass)
+                .accessibilityLabel("Previous page")
+            }
+
+            Button(action: onContinue) {
+                FullWidthGlassButtonLabel(
+                    isLastPage ? "Start Using ImageDropX" : "Continue",
+                    systemImage: isLastPage ? "checkmark" : "arrow.right"
                 )
-            VStack(alignment: .leading, spacing: 10) {
-                Text("\(number). \(text)")
-                    .font(.body)
-                    .frame(maxWidth: .infinity, alignment: .leading)
             }
+            .buttonStyle(.glassProminent)
+            .accessibilityIdentifier(isLastPage ? "finish-onboarding" : "continue-onboarding")
         }
+        .padding(.top, 8)
     }
 }
-
-struct HelpGuideIntroPage: View {
-    let nextAction: () -> Void
-    @Binding var showHelpGuide: Bool
-
-    var body: some View {
-        VStack(spacing: 20) {
-            Spacer()
-            Text("Need Help?")
-                .font(.title)
-                .fontWeight(.bold)
-            Text("Access the Help Guide anytime for detailed instructions on setting up your server and using the app.")
-                .font(.body)
-                .multilineTextAlignment(.center)
-                .padding(.horizontal)
-            Button("View Help Guide") {
-                showHelpGuide = true
-            }
-            .frame(maxWidth: .infinity)
-            .padding()
-            .background(Color.gray)
-            .foregroundStyle(.white)
-            .clipShape(RoundedRectangle(cornerRadius: 10))
-            .padding(.horizontal)
-            Spacer()
-            Button("Next") {
-                nextAction()
-            }
-            .frame(maxWidth: .infinity)
-            .padding()
-            .background(Color.blue)
-            .foregroundStyle(.white)
-            .clipShape(RoundedRectangle(cornerRadius: 10))
-            .padding(.horizontal)
-        }
-        .padding(.vertical)
-    }
-}
-
-struct CompletionPage: View {
-    let completeAction: () -> Void
-
-    var body: some View {
-        VStack(spacing: 20) {
-            Spacer()
-            Text("You're Ready!")
-                .font(.title)
-                .fontWeight(.bold)
-            Text("Start capturing and uploading images now. Set up server details in Settings if you haven't already.")
-                .font(.body)
-                .multilineTextAlignment(.center)
-                .padding(.horizontal)
-            Image(systemName: "checkmark.circle.fill")
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .frame(width: 100, height: 100)
-                .foregroundStyle(.green)
-            Spacer()
-            Button("Start Using ImageDropX") {
-                completeAction()
-            }
-            .frame(maxWidth: .infinity)
-            .padding()
-            .background(Color.blue)
-            .foregroundStyle(.white)
-            .clipShape(RoundedRectangle(cornerRadius: 10))
-            .padding(.horizontal)
-        }
-        .padding(.vertical)
-    }
-}
-
-struct NetworkSetupView: View {
-    @EnvironmentObject var appData: AppData
-    let nextAction: () -> Void
-    @AppStorage(Constants.UserDefaults.ocrMode) private var ocrModeRawValue: String = OCRMode.full.rawValue
-    @State private var targetDirectory = ""
-    @State private var username = ""
-    @State private var password = ""
-    @State private var port = ""
-    @State private var showWarning = false
-    @State private var showError = false
-    @State private var errorMessage = ""
-    @State private var showSuccess = false
-    @State private var networkInfo: NetworkInfo?
-    @State private var isDiscovering = false
-    @State private var discoveryProgress = "Initializing..."
-    @State private var discoveryTask: Task<Void, Never>? = nil
-    @State private var showDiscoveryResults = false
-
-    var canAutoFill: Bool {
-        !targetDirectory.isEmpty && !username.isEmpty && !password.isEmpty
-    }
-    
-    private var ocrModeBinding: Binding<OCRMode> {
-        Binding(
-            get: { OCRMode(rawValue: ocrModeRawValue) ?? .full },
-            set: { ocrModeRawValue = $0.rawValue }
-        )
-    }
-
-    private func stopAutoFill() {
-        discoveryTask?.cancel()
-        discoveryTask = nil
-        isDiscovering = false
-        discoveryProgress = "Ready"
-    }
-
-    var body: some View {
-        VStack(spacing: 20) {
-            Spacer()
-            Text("Network Setup")
-                .font(.title)
-                .fontWeight(.bold)
-            Text("Enter the target folder and credentials to auto-fill server details (recommended). You can skip and set up later.")
-                .font(.subheadline)
-                .multilineTextAlignment(.center)
-                .foregroundStyle(.gray)
-                .padding(.horizontal)
-            Form {
-                if isDiscovering {
-                    HStack(spacing: 15) {
-                        ProgressView()
-                            .controlSize(.small)
-                        Text(discoveryProgress)
-                            .foregroundStyle(.blue)
-                            .font(.caption)
-                        Spacer()
-                        Button("Cancel") {
-                            stopAutoFill()
-                        }
-                        .buttonStyle(.borderless)
-                        .foregroundStyle(.red)
-                    }
-                    .padding(.vertical, 4)
-                }
-                
-                TextField("Target Directory (e.g., MediaCapture)", text: $targetDirectory)
-                    .autocapitalization(.none)
-                TextField("Username (e.g., WORKGROUP\\user)", text: $username)
-                    .textContentType(.username)
-                SecureField("Password", text: $password)
-                    .textContentType(.password)
-                TextField("Port (optional)", text: $port)
-                    .keyboardType(.numberPad)
-                Section("OCR") {
-                    Picker("OCR Mode", selection: ocrModeBinding) {
-                        ForEach(OCRMode.allCases) { mode in
-                            Text(mode.displayName).tag(mode)
-                        }
-                    }
-                    .pickerStyle(.segmented)
-                }
-            }
-            .frame(maxHeight: 260)
-            
-            Button("Browse & Auto-Fill") {
-                showDiscoveryResults = true
-            }
-            .frame(maxWidth: .infinity)
-            .padding()
-            .background(canAutoFill ? Color.blue : Color.gray)
-            .foregroundStyle(.white)
-            .clipShape(RoundedRectangle(cornerRadius: 10))
-            .padding(.horizontal)
-            .disabled(!canAutoFill || isDiscovering)
-            
-            Button("Skip") {
-                showWarning = true
-            }
-            .foregroundStyle(.gray)
-            Spacer()
-        }
-        .sheet(isPresented: $showDiscoveryResults) {
-            DiscoveryResultsView(
-                username: username,
-                password: password,
-                port: Int(port),
-                onSelect: { info in
-                    networkInfo = info
-                    showSuccess = true
-                }
-            )
-            .environmentObject(appData)
-        }
-        .alert("Settings Incomplete", isPresented: $showWarning) {
-            Button("Set Up Now", role: .cancel) {}
-            Button("Skip Anyway") { nextAction() }
-        } message: {
-            Text("Uploads won't work without server details. Set them up in Settings later if you skip now.")
-        }
-        .alert("Network Error", isPresented: $showError) {
-            Button("Try Again", role: .cancel) {}
-            Button("Skip") { nextAction() }
-        } message: {
-            Text(errorMessage)
-        }
-        .alert("Success", isPresented: $showSuccess) {
-            Button("Save") { saveSettings() }
-            Button("Discard") { nextAction() }
-        } message: {
-            Text("Server details retrieved successfully:\nIP: \(networkInfo?.serverIP ?? "")\nShare: \(networkInfo?.shareName ?? "")\nPath: \(networkInfo?.targetDirectory ?? "")")
-        }
-    }
-
-    private func autoFillNetworkInfo() {
-        discoveryTask?.cancel()
-        discoveryTask = Task {
-            await performAutoFill()
-        }
-    }
-
-    private func performAutoFill() async {
-        isDiscovering = true
-        discoveryProgress = "Checking network connection..."
-        
-        defer {
-            Task { @MainActor in
-                isDiscovering = false
-                discoveryTask = nil
-            }
-        }
-        
-        do {
-            let portNumber = Int(port)
-            discoveryProgress = "Searching for SMB servers..."
-            // Use direct IP from existing settings if present; otherwise nil
-            let directIPFromSettings = appData.settings.serverIP.trimmingCharacters(in: .whitespacesAndNewlines)
-            let directIP = directIPFromSettings.isEmpty ? nil : directIPFromSettings
-
-            let info = try await appData.discoveryService.retrieveNetworkInfo(
-                targetFolder: targetDirectory,
-                username: username,
-                password: password,
-                directIP: directIP,
-                port: portNumber,
-                onStatus: { status in
-                    Task { @MainActor in
-                        guard !Task.isCancelled else { return }
-                        appData.connectionStatus = status
-                        switch status {
-                        case .discovery(let state):
-                            switch state {
-                            case .subnetScan(let progress):
-                                discoveryProgress = "Scanning subnet (\(Int(progress * 100))%)..."
-                            case .bonjourSearch:
-                                discoveryProgress = "Searching via Bonjour..."
-                            case .resolving(let name):
-                                discoveryProgress = "Resolving \(name)..."
-                            }
-                        case .connecting(let host):
-                            discoveryProgress = "Connecting to \(host)..."
-                        case .authenticating:
-                            discoveryProgress = "Authenticating..."
-                        case .connected:
-                            discoveryProgress = "Connected!"
-                        case .failure(let error):
-                            discoveryProgress = "Failed: \(error.localizedDescription)"
-                        case .disconnected:
-                            discoveryProgress = "Ready"
-                        }
-                    }
-                }
-            )
-            
-            if Task.isCancelled { return }
-                
-            await MainActor.run {
-                networkInfo = info
-                showSuccess = true
-            }
-        } catch is CancellationError {
-            // Cancelled
-        } catch {
-            if !Task.isCancelled {
-                await MainActor.run {
-                    showError = true
-                    errorMessage = "Failed to retrieve network info: \(error.localizedDescription)"
-                }
-            }
-        }
-    }
-
-    private func saveSettings() {
-        guard let info = networkInfo else { return }
-        
-        // Validate port if provided
-        let portNumber: Int?
-        if !port.isEmpty {
-            guard let number = Int(port), number > 0, number <= 65535 else {
-                showError = true
-                errorMessage = "Please enter a valid port number (1-65535)"
-                return
-            }
-            portNumber = number
-        } else {
-            portNumber = nil
-        }
-        
-        appData.settings = ServerSettings(
-            serverIP: info.serverIP,
-            shareName: info.shareName,
-            targetDirectory: info.targetDirectory,
-            username: username,
-            port: portNumber
-        )
-        try? appData.savePassword(password)
-        nextAction()
-    }
-}
-
-// Rest of the file (OnboardingView, other view structures) remains unchanged...
 
 #Preview {
     OnboardingView()
-        .environmentObject(AppData.preview)
 }

--- a/LANImageUploader/OnboardingView.swift
+++ b/LANImageUploader/OnboardingView.swift
@@ -22,7 +22,7 @@ public struct OnboardingView: View {
                 )
 
                 TabView(selection: $selectedPage) {
-                    ForEach(Array(pages.enumerated()), id: \.element) { index, page in
+                    ForEach(Array(pages.enumerated()), id: \.element) { (index, page) in
                         OnboardingPageView(page: page)
                             .tag(index)
                     }

--- a/LANImageUploader/SettingsView.swift
+++ b/LANImageUploader/SettingsView.swift
@@ -174,7 +174,7 @@ struct SettingsView: View {
 
     var firstSetupView: some View {
         Group {
-            Section("First Setup") {
+            Section("Server Connection") {
                 Text("Enter your credentials and target folder. Then choose 'Auto-Fill' to detect your SMB server automatically, or select 'Try Direct IP' if you already know the server's IP address. Note: Sometimes 'Auto-Fill' cannot extract the server info automatically. This app stores your password in a secure keychain.")
                     .font(.caption)
                     .foregroundStyle(.gray)
@@ -285,7 +285,7 @@ struct SettingsView: View {
 
     var completeSetupView: some View {
         Group {
-            Section("Server Configuration") {
+            Section("Server Connection") {
                 if isDiscovering {
                     HStack(spacing: 15) {
                         ProgressView()

--- a/LANImageUploaderTests/LANImageUploaderTests.swift
+++ b/LANImageUploaderTests/LANImageUploaderTests.swift
@@ -29,6 +29,53 @@ private final class ProgressRecorder: @unchecked Sendable {
 
 struct LANImageUploaderTests {
 
+    @Test func onboardingCoversTheApprovedFourChapterFlow() {
+        #expect(OnboardingPage.allCases == [.privacy, .capture, .organize, .ready])
+        #expect(OnboardingPage.capture.message.localizedCaseInsensitiveContains("multi-page"))
+        #expect(OnboardingPage.organize.message.localizedCaseInsensitiveContains("PDF"))
+        #expect(OnboardingPage.ready.detailItems.contains { $0.title == "Settings > Server Connection" })
+    }
+
+    @Test func helpContentCoversEveryTopic() {
+        for topic in HelpTopic.allCases {
+            #expect(!topic.articles.isEmpty, "Expected at least one article for \(topic.title)")
+        }
+    }
+
+    @Test func helpSearchIndexesTitlesKeywordsAndSteps() {
+        #expect(HelpContent.search("multi-page").contains { $0.id == "scan-document" })
+        #expect(HelpContent.search("direct IP").contains { $0.id == "connect-server" })
+        #expect(HelpContent.search("page numbers compression").contains { $0.id == "pdf-settings" })
+    }
+
+    @Test func helpSearchRequiresEverySearchTerm() {
+        let results = HelpContent.search("server password")
+
+        #expect(results.contains { $0.id == "connect-server" })
+        #expect(!results.contains { $0.id == "capture-photo" })
+    }
+
+    @Test func serverConnectionRequiresEveryUploadCredential() {
+        let complete = ServerSettings(
+            serverIP: "192.168.1.10",
+            shareName: "Images",
+            targetDirectory: nil,
+            username: "uploader",
+            port: nil
+        )
+        let missingShare = ServerSettings(
+            serverIP: "192.168.1.10",
+            shareName: " ",
+            targetDirectory: nil,
+            username: "uploader",
+            port: nil
+        )
+
+        #expect(ServerConnectionReadiness.isComplete(settings: complete, password: "secret"))
+        #expect(!ServerConnectionReadiness.isComplete(settings: complete, password: nil))
+        #expect(!ServerConnectionReadiness.isComplete(settings: missingShare, password: "secret"))
+    }
+
     @Test @MainActor func appDataInitialization() async throws {
         let mockFile = MockFileService()
         let mockUpload = MockImageUploadService()

--- a/docs/superpowers/plans/2026-06-06-onboarding-help-refresh-plan.md
+++ b/docs/superpowers/plans/2026-06-06-onboarding-help-refresh-plan.md
@@ -1,0 +1,14 @@
+# Onboarding and Help Refresh Implementation Plan
+
+1. Add reusable iOS 26 glass surfaces and buttons that match the existing app
+   background and remain accessible.
+2. Replace the existing onboarding wizard with the approved four-page flow,
+   including progress, skip, completion, Dynamic Type, and Reduce Motion.
+3. Create typed Help topics and articles, then replace HelpGuideView with a
+   searchable topic/article experience and quick actions.
+4. Add the conditional Home server-setup card and value-based navigation to
+   Settings.
+5. Add focused unit tests for Help search/content and onboarding page coverage.
+6. Build and test on the known iOS 26.5 simulator destination.
+7. Launch and inspect onboarding, Home, and Help with semantic simulator tools,
+   then run an accessibility audit.

--- a/docs/superpowers/specs/2026-06-06-onboarding-help-refresh-design.md
+++ b/docs/superpowers/specs/2026-06-06-onboarding-help-refresh-design.md
@@ -1,0 +1,88 @@
+# Onboarding and Help Refresh
+
+## Goal
+
+Modernize ImageDropX onboarding and help for iOS 26 while accurately covering
+photo capture, document scanning, PDF creation, local gallery management,
+archives, and SMB upload.
+
+## Product Decisions
+
+- Keep all new copy in English to match the existing app.
+- Optimize onboarding for a fast start rather than server configuration.
+- Explain that SMB upload is configured in Settings.
+- Show a persistent Home setup card until required server settings exist.
+- Provide a complete, searchable, offline Help Center.
+- Use native iOS 26 Liquid Glass APIs and accessible SwiftUI layouts.
+
+## Onboarding
+
+Use four full-screen chapters:
+
+1. **Welcome and privacy**: Images and documents remain on-device until upload.
+2. **Capture and scan**: Explain photo capture, document scanning, edge
+   detection, and multi-page capture.
+3. **Organize and create PDF**: Explain Gallery actions, archive, and PDF output.
+4. **Ready and setup location**: Direct users to
+   `Settings > Server Connection` and explain the Home setup card.
+
+The flow supports swipe navigation and explicit Back, Continue, Skip, and Start
+actions. Page indicators expose progress. Dynamic Type may scroll vertically.
+Reduced Motion removes decorative transitions. Skipping or completing marks
+onboarding complete. Help can replay it.
+
+## Home Setup Card
+
+When server IP, share name, username, or password is missing, Home displays a
+prominent setup card above the primary actions. The card explains that capture
+works immediately but upload needs an SMB connection. Its action navigates to
+Settings. It disappears automatically when required settings are complete.
+
+## Help Center
+
+Replace the current text list with a searchable, offline Help Center.
+
+The overview contains:
+
+- Search.
+- Quick actions for server setup and replaying onboarding.
+- Topic cards for Photos and Scanner, Gallery and PDF, Upload and Server,
+  Archive and Files, Privacy and Storage, and Troubleshooting.
+
+Articles use typed Swift data with a title, summary, searchable keywords,
+numbered steps, and optional tip or warning. Initial coverage includes:
+
+- Photo capture and retake.
+- Document scanning, auto-capture, crop, rotate, and review.
+- Gallery selection, rename, reorder, delete, and output choices.
+- Single-PDF creation and PDF settings.
+- Archive and restore.
+- Server discovery and manual configuration.
+- Upload, duplicate handling, trial limits, and common failures.
+- Privacy, on-device storage, permissions, and network troubleshooting.
+
+## Visual System
+
+- Retain the app's animated blue/purple background with restrained movement.
+- Use native `GlassEffectContainer`, `glassEffect`, and glass button styles.
+- Use consistent continuous rounded rectangles and SF Symbols.
+- Reserve tinted glass for primary actions and status communication.
+- Avoid glass on dense article text; use readable grouped content surfaces.
+- Support light/dark mode, Dynamic Type, VoiceOver, and Reduce Motion.
+
+## Architecture
+
+- Replace the oversized onboarding file with focused page and component types.
+- Keep article content in a dedicated Help content model.
+- Keep navigation local to each feature using SwiftUI value-based destinations.
+- Continue using the existing `AppData` environment object and
+  `onboardingCompleted` AppStorage key.
+- Do not change storage, SMB, signing, entitlements, or project configuration.
+
+## Verification
+
+- Build the app on `LANImageUploader iPhone 17 Pro`, iOS 26.5.
+- Exercise onboarding completion, skip, and replay.
+- Verify the setup card appears with incomplete settings and routes to Settings.
+- Verify Help search and article navigation.
+- Run an accessibility audit and inspect primary screens at large text sizes.


### PR DESCRIPTION
## Summary

- replace the legacy onboarding wizard with a focused four-step iOS 26 Liquid Glass flow
- add a searchable, offline Help Center covering scanning, PDF creation, gallery, archives, SMB upload, privacy, and troubleshooting
- add a persistent Home server-setup card and modernize the Home action layout
- add regression coverage for onboarding content, Help search, topic coverage, and server readiness

## User impact

New users can start capturing immediately while receiving a clear path to SMB configuration. Existing users get a complete in-app support surface that reflects the current scanner and PDF workflows.

## Validation

- iOS 26.5 simulator build succeeded with no implementation warnings
- 39 tests passed, 0 failed, 3 intentionally skipped template UI tests
- semantic simulator verification completed for onboarding, Help Center, replay, Home actions, and server setup routing
- accessibility audit reported 0 critical issues
