### PR TITLE
[codex] Preserve scanner audio and fix document crop mapping

### DIFF
--- a/LANImageUploader/AppData.swift
+++ b/LANImageUploader/AppData.swift
@@ -191,6 +191,7 @@ class AppData: ObservableObject {
     func saveCapturedImage(
         _ image: UIImage,
         crop: DocumentCrop? = nil,
+        isDocumentScan: Bool? = nil,
         capturedAt date: Date = Date()
     ) async throws -> CapturedImage {
         let formatter = DateFormatter()
@@ -207,7 +208,7 @@ class AppData: ObservableObject {
             name: fileName.removingSuffix(".jpg"),
             fileURL: fileURL,
             crop: crop,
-            isDocumentScan: crop != nil
+            isDocumentScan: isDocumentScan ?? (crop != nil)
         )
 
         await MainActor.run {

--- a/LANImageUploader/AppData.swift
+++ b/LANImageUploader/AppData.swift
@@ -10,6 +10,28 @@ import Combine
 import Security
 import SwiftUI
 
+final class CapturedImageTimestampFormatter: @unchecked Sendable {
+    static let shared = CapturedImageTimestampFormatter()
+
+    private let lock = NSLock()
+    private let formatter: DateFormatter
+
+    private init() {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.dateFormat = "yyyyMMdd_HHmmss"
+        self.formatter = formatter
+    }
+
+    func string(from date: Date, timeZone: TimeZone = .current) -> String {
+        lock.withLock {
+            formatter.timeZone = timeZone
+            return formatter.string(from: date)
+        }
+    }
+}
+
 struct NetworkInfo: Equatable {
     let serverIP: String
     let shareName: String
@@ -194,9 +216,7 @@ class AppData: ObservableObject {
         isDocumentScan: Bool? = nil,
         capturedAt date: Date = Date()
     ) async throws -> CapturedImage {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyyMMdd_HHmmss"
-        let timestamp = formatter.string(from: date)
+        let timestamp = CapturedImageTimestampFormatter.shared.string(from: date)
         let fileName = "IMG_\(timestamp).jpg"
 
         guard let data = image.jpegData(compressionQuality: 0.8) else {
@@ -269,9 +289,7 @@ class AppData: ObservableObject {
     // Save images to a dated folder
     // Save a new captured image, reusable for camera and retake
     func saveCapturedUIImage(_ image: UIImage, suggestedPrefix: String = "IMG") async throws -> CapturedImage {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyyMMdd_HHmmss"
-        let timestamp = dateFormatter.string(from: Date())
+        let timestamp = CapturedImageTimestampFormatter.shared.string(from: Date())
         let fileName = "\(suggestedPrefix)_\(timestamp).jpg"
 
         guard let data = image.jpegData(compressionQuality: 0.8) else {

--- a/LANImageUploader/CameraPicker.swift
+++ b/LANImageUploader/CameraPicker.swift
@@ -780,6 +780,10 @@ final class DocumentCameraViewController: UIViewController, AVCapturePhotoCaptur
     private let session = AVCaptureSession()
     private let sessionQueue = DispatchQueue(label: "ImageDrop.scanner.session")
     private let detectionQueue = DispatchQueue(label: "ImageDrop.scanner.detection")
+    private let photoProcessingQueue = DispatchQueue(
+        label: "ImageDrop.scanner.photo-processing",
+        qos: .userInitiated
+    )
     private let photoOutput = AVCapturePhotoOutput()
     private let videoOutput = AVCaptureVideoDataOutput()
     private let previewLayer = AVCaptureVideoPreviewLayer()
@@ -1000,25 +1004,35 @@ final class DocumentCameraViewController: UIViewController, AVCapturePhotoCaptur
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
             self.captureInProgress = false
-            if let image {
-                if self.pendingCaptureMode == .scan {
+            guard let image else { return }
+            let captureMode = self.pendingCaptureMode
+            let detection = self.pendingCaptureDetection
+            let previewSize = self.pendingPhotoPreviewSize
+            self.photoProcessingQueue.async { [weak self] in
+                guard let self else { return }
+                if captureMode == .scan {
                     let upright = PhotoCaptureFraming.normalizedOrientationImage(image)
                     let photoSize = upright.cgImage.map {
                         CGSize(width: $0.width, height: $0.height)
                     } ?? upright.size
-                    let crop = self.pendingCaptureDetection?
+                    let crop = detection?
                         .crop
                         .mapped(
-                            fromAspectFillImageSize: self.pendingCaptureDetection?.orientedBufferSize ?? .zero,
+                            fromAspectFillImageSize: detection?.orientedBufferSize ?? .zero,
                             toImageSize: photoSize
                         )
                         .flatMap { $0.isValidForPerspectiveCorrection() ? $0.clamped() : nil }
-                    self.onScanCapture?(upright, crop)
+                    DispatchQueue.main.async {
+                        self.onScanCapture?(upright, crop)
+                    }
                 } else {
-                    self.onPhotoCapture?(PhotoCaptureFraming.image(
+                    let framed = PhotoCaptureFraming.image(
                         image,
-                        matchingAspectFillPreview: self.pendingPhotoPreviewSize
-                    ))
+                        matchingAspectFillPreview: previewSize
+                    )
+                    DispatchQueue.main.async {
+                        self.onPhotoCapture?(framed)
+                    }
                 }
             }
         }

--- a/LANImageUploader/CameraPicker.swift
+++ b/LANImageUploader/CameraPicker.swift
@@ -18,6 +18,32 @@ enum ScannerCapturePolicy {
     static let includesAudioInput = false
 }
 
+enum DocumentCaptureOrientation {
+    static func visionOrientation(forVideoRotationAngle angle: CGFloat) -> CGImagePropertyOrientation {
+        switch normalizedAngle(angle) {
+        case 0: return .up
+        case 90: return .right
+        case 180: return .down
+        case 270: return .left
+        default: return .up
+        }
+    }
+
+    static func orientedSize(_ size: CGSize, orientation: CGImagePropertyOrientation) -> CGSize {
+        switch orientation {
+        case .left, .leftMirrored, .right, .rightMirrored:
+            return CGSize(width: size.height, height: size.width)
+        default:
+            return size
+        }
+    }
+
+    private static func normalizedAngle(_ angle: CGFloat) -> Int {
+        let rounded = Int(angle.rounded()) % 360
+        return rounded >= 0 ? rounded : rounded + 360
+    }
+}
+
 struct CameraPicker: UIViewControllerRepresentable {
     @Binding var image: UIImage?
     @Environment(\.dismiss) var dismiss
@@ -128,7 +154,7 @@ struct PhotoCaptureFraming {
         return UIImage(cgImage: framed, scale: upright.scale, orientation: .up)
     }
 
-    private static func normalizedOrientationImage(_ image: UIImage) -> UIImage {
+    static func normalizedOrientationImage(_ image: UIImage) -> UIImage {
         guard image.imageOrientation != .up else { return image }
         let format = UIGraphicsImageRendererFormat()
         format.scale = image.scale
@@ -702,6 +728,12 @@ struct DocumentCameraPreview: UIViewControllerRepresentable {
 }
 
 final class DocumentCameraViewController: UIViewController, AVCapturePhotoCaptureDelegate, AVCaptureVideoDataOutputSampleBufferDelegate {
+    private struct DetectedCrop {
+        let crop: DocumentCrop
+        let orientedBufferSize: CGSize
+        let orientationGeneration: Int
+    }
+
 #if DEBUG
     private static let audioLogger = Logger(
         subsystem: Bundle.main.bundleIdentifier ?? "ImageDrop",
@@ -754,13 +786,13 @@ final class DocumentCameraViewController: UIViewController, AVCapturePhotoCaptur
     private let boundaryLayer = CAShapeLayer()
     private let focusLayer = CAShapeLayer()
     private var activeDevice: AVCaptureDevice?
-    private var latestCrop: DocumentCrop?
+    private var latestDetection: DetectedCrop?
     private var displayedCrop: DocumentCrop?
     private var previousCrop: DocumentCrop?
     private var stableSince: Date?
     private var lastAutoCaptureAt = Date.distantPast
     private var lastDetectionAt = Date.distantPast
-    private var pendingCaptureCrop: DocumentCrop = .fullFrame
+    private var pendingCaptureDetection: DetectedCrop?
     private var pendingCaptureMode: CameraCaptureMode = .scan
     private var captureInProgress = false
     private var waitingForNextAutoPage = false
@@ -768,6 +800,10 @@ final class DocumentCameraViewController: UIViewController, AVCapturePhotoCaptur
     private var visibleCountdown: Int?
     private var pendingPhotoPreviewSize: CGSize = .zero
     private var previewImageSize: CGSize = .zero
+    private let orientationLock = NSLock()
+    private var visionOrientation: CGImagePropertyOrientation = .right
+    private var orientationGeneration = 0
+    private var appliedVideoRotationAngle: CGFloat = -1
     private let autoCaptureHoldDuration: TimeInterval = 2.4
 
     override func viewDidLoad() {
@@ -896,10 +932,21 @@ final class DocumentCameraViewController: UIViewController, AVCapturePhotoCaptur
 
     private func updateCaptureOrientation() {
         let angle = currentVideoRotationAngle()
+        if angle != appliedVideoRotationAngle {
+            appliedVideoRotationAngle = angle
+            orientationLock.withLock {
+                visionOrientation = DocumentCaptureOrientation.visionOrientation(forVideoRotationAngle: angle)
+                orientationGeneration += 1
+            }
+            latestDetection = nil
+            displayedCrop = nil
+            previewImageSize = .zero
+            boundaryLayer.path = nil
+            resetAutoCaptureState()
+        }
         setVideoRotationAngle(angle, on: previewLayer.connection)
         sessionQueue.async { [weak self] in
             guard let self else { return }
-            self.setVideoRotationAngle(angle, on: self.videoOutput.connection(with: .video))
             self.setVideoRotationAngle(angle, on: self.photoOutput.connection(with: .video))
         }
     }
@@ -928,11 +975,14 @@ final class DocumentCameraViewController: UIViewController, AVCapturePhotoCaptur
         guard session.isRunning, !captureInProgress else { return }
         captureInProgress = true
         pendingCaptureMode = mode
-        pendingCaptureCrop = mode == .scan ? (latestCrop ?? .fullFrame) : .fullFrame
+        let currentGeneration = orientationLock.withLock { orientationGeneration }
+        pendingCaptureDetection = mode == .scan
+            ? latestDetection.flatMap { $0.orientationGeneration == currentGeneration ? $0 : nil }
+            : nil
         pendingPhotoPreviewSize = previewLayer.bounds.size
         if autoTriggered, mode == .scan {
             waitingForNextAutoPage = true
-            lastAutoCapturedCrop = pendingCaptureCrop
+            lastAutoCapturedCrop = pendingCaptureDetection?.crop
         }
         let settings = AVCapturePhotoSettings()
         settings.flashMode = photoOutput.supportedFlashModes.contains(.auto) ? .auto : .off
@@ -952,7 +1002,18 @@ final class DocumentCameraViewController: UIViewController, AVCapturePhotoCaptur
             self.captureInProgress = false
             if let image {
                 if self.pendingCaptureMode == .scan {
-                    self.onScanCapture?(image, self.pendingCaptureCrop)
+                    let upright = PhotoCaptureFraming.normalizedOrientationImage(image)
+                    let photoSize = upright.cgImage.map {
+                        CGSize(width: $0.width, height: $0.height)
+                    } ?? upright.size
+                    let crop = self.pendingCaptureDetection?
+                        .crop
+                        .mapped(
+                            fromAspectFillImageSize: self.pendingCaptureDetection?.orientedBufferSize ?? .zero,
+                            toImageSize: photoSize
+                        )
+                        .flatMap { $0.isValidForPerspectiveCorrection() ? $0.clamped() : nil }
+                    self.onScanCapture?(upright, crop ?? .fullFrame)
                 } else {
                     self.onPhotoCapture?(PhotoCaptureFraming.image(
                         image,
@@ -969,11 +1030,18 @@ final class DocumentCameraViewController: UIViewController, AVCapturePhotoCaptur
         from connection: AVCaptureConnection
     ) {
         guard mode == .scan else { return }
+        let orientationState = orientationLock.withLock {
+            (visionOrientation, orientationGeneration)
+        }
         let currentPreviewImageSize: CGSize?
         if let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) {
-            currentPreviewImageSize = CGSize(
+            let rawSize = CGSize(
                 width: CVPixelBufferGetWidth(pixelBuffer),
                 height: CVPixelBufferGetHeight(pixelBuffer)
+            )
+            currentPreviewImageSize = DocumentCaptureOrientation.orientedSize(
+                rawSize,
+                orientation: orientationState.0
             )
         } else {
             currentPreviewImageSize = nil
@@ -984,31 +1052,44 @@ final class DocumentCameraViewController: UIViewController, AVCapturePhotoCaptur
             guard let self else { return }
             let observation = (request.results as? [VNRectangleObservation])?.first
             let crop = observation.map {
-                DocumentCrop(
-                    topLeft: CGPoint(x: $0.topLeft.x, y: 1 - $0.topLeft.y),
-                    topRight: CGPoint(x: $0.topRight.x, y: 1 - $0.topRight.y),
-                    bottomRight: CGPoint(x: $0.bottomRight.x, y: 1 - $0.bottomRight.y),
-                    bottomLeft: CGPoint(x: $0.bottomLeft.x, y: 1 - $0.bottomLeft.y)
-                ).clamped()
+                DocumentCrop.visionNormalized(
+                    topLeft: $0.topLeft,
+                    topRight: $0.topRight,
+                    bottomRight: $0.bottomRight,
+                    bottomLeft: $0.bottomLeft
+                )
             }
             DispatchQueue.main.async { [weak self, currentPreviewImageSize] in
-                if let currentPreviewImageSize {
-                    self?.previewImageSize = currentPreviewImageSize
+                guard let self else { return }
+                let currentGeneration = self.orientationLock.withLock { self.orientationGeneration }
+                guard currentGeneration == orientationState.1 else { return }
+                if let crop, let currentPreviewImageSize {
+                    self.latestDetection = DetectedCrop(
+                        crop: crop,
+                        orientedBufferSize: currentPreviewImageSize,
+                        orientationGeneration: orientationState.1
+                    )
+                    self.previewImageSize = currentPreviewImageSize
+                } else {
+                    self.latestDetection = nil
                 }
-                self?.handleDetectedCrop(crop)
+                self.handleDetectedCrop(crop)
             }
         }
         request.maximumObservations = 1
         request.minimumConfidence = 0.6
         request.minimumSize = 0.18
         request.quadratureTolerance = 35
-        try? VNImageRequestHandler(cmSampleBuffer: sampleBuffer, orientation: .up).perform([request])
+        try? VNImageRequestHandler(
+            cmSampleBuffer: sampleBuffer,
+            orientation: orientationState.0
+        ).perform([request])
     }
 
     private func handleDetectedCrop(_ detectedCrop: DocumentCrop?) {
         guard mode == .scan else { return }
         guard let crop = detectedCrop else {
-            latestCrop = nil
+            latestDetection = nil
             displayedCrop = nil
             boundaryLayer.removeAllAnimations()
             boundaryLayer.path = nil
@@ -1029,7 +1110,6 @@ final class DocumentCameraViewController: UIViewController, AVCapturePhotoCaptur
            DocumentCaptureQuality.averageMovement(from: capturedCrop, to: crop) > 0.08 {
             waitingForNextAutoPage = false
         }
-        latestCrop = crop
         let displayCrop = DocumentCaptureQuality.smoothedDisplayCrop(from: displayedCrop, toward: crop)
         displayedCrop = displayCrop
         drawBoundary(displayCrop, aligned: acceptable)
@@ -1094,7 +1174,7 @@ final class DocumentCameraViewController: UIViewController, AVCapturePhotoCaptur
         stableSince = nil
         previousCrop = nil
         waitingForNextAutoPage = false
-        latestCrop = nil
+        latestDetection = nil
         displayedCrop = nil
         updateCountdown(nil)
     }

--- a/LANImageUploader/CameraPicker.swift
+++ b/LANImageUploader/CameraPicker.swift
@@ -9,6 +9,14 @@ import SwiftUI
 import UIKit
 @preconcurrency import AVFoundation
 import Vision
+#if DEBUG
+import OSLog
+#endif
+
+enum ScannerCapturePolicy {
+    static let automaticallyConfiguresApplicationAudioSession = false
+    static let includesAudioInput = false
+}
 
 struct CameraPicker: UIViewControllerRepresentable {
     @Binding var image: UIImage?
@@ -17,6 +25,8 @@ struct CameraPicker: UIViewControllerRepresentable {
     func makeUIViewController(context: Context) -> UIImagePickerController {
         let picker = UIImagePickerController()
         picker.sourceType = .camera
+        picker.mediaTypes = ["public.image"]
+        picker.cameraCaptureMode = .photo
         picker.delegate = context.coordinator
         return picker
     }
@@ -692,6 +702,13 @@ struct DocumentCameraPreview: UIViewControllerRepresentable {
 }
 
 final class DocumentCameraViewController: UIViewController, AVCapturePhotoCaptureDelegate, AVCaptureVideoDataOutputSampleBufferDelegate {
+#if DEBUG
+    private static let audioLogger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "ImageDrop",
+        category: "CameraAudioSession"
+    )
+#endif
+
     private let modeLock = NSLock()
     private var storedMode: CameraCaptureMode = .scan
     var mode: CameraCaptureMode {
@@ -771,6 +788,26 @@ final class DocumentCameraViewController: UIViewController, AVCapturePhotoCaptur
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(focusAndExpose(at:)))
         tapGesture.cancelsTouchesInView = false
         view.addGestureRecognizer(tapGesture)
+#if DEBUG
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleAudioSessionInterruption(_:)),
+            name: AVAudioSession.interruptionNotification,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleAudioRouteChange(_:)),
+            name: AVAudioSession.routeChangeNotification,
+            object: nil
+        )
+#endif
+    }
+
+    deinit {
+#if DEBUG
+        NotificationCenter.default.removeObserver(self)
+#endif
     }
 
     override func viewDidLayoutSubviews() {
@@ -808,9 +845,12 @@ final class DocumentCameraViewController: UIViewController, AVCapturePhotoCaptur
     private func configureAndStartSession() {
         sessionQueue.async { [weak self] in
             guard let self, !self.session.isRunning else { return }
+            self.session.automaticallyConfiguresApplicationAudioSession =
+                ScannerCapturePolicy.automaticallyConfiguresApplicationAudioSession
             self.session.beginConfiguration()
             self.session.sessionPreset = .photo
             guard let device = self.preferredBackCamera(),
+                  device.hasMediaType(.video),
                   let input = try? AVCaptureDeviceInput(device: device),
                   self.session.canAddInput(input) else {
                 self.session.commitConfiguration()
@@ -831,6 +871,9 @@ final class DocumentCameraViewController: UIViewController, AVCapturePhotoCaptur
                 self.updateCaptureOrientation()
             }
             self.session.startRunning()
+#if DEBUG
+            assert(!self.session.inputs.contains { $0.ports.contains { $0.mediaType == .audio } })
+#endif
             let options = self.zoomOptions(for: device)
             let currentFactor = self.nearestZoomFactor(to: device.videoZoomFactor, options: options)
             DispatchQueue.main.async {
@@ -838,6 +881,18 @@ final class DocumentCameraViewController: UIViewController, AVCapturePhotoCaptur
             }
         }
     }
+
+#if DEBUG
+    @objc private func handleAudioSessionInterruption(_ notification: Notification) {
+        let rawType = notification.userInfo?[AVAudioSessionInterruptionTypeKey] as? UInt
+        Self.audioLogger.debug("Observed audio interruption type: \(rawType.map(String.init) ?? "unknown", privacy: .public)")
+    }
+
+    @objc private func handleAudioRouteChange(_ notification: Notification) {
+        let rawReason = notification.userInfo?[AVAudioSessionRouteChangeReasonKey] as? UInt
+        Self.audioLogger.debug("Observed audio route change reason: \(rawReason.map(String.init) ?? "unknown", privacy: .public)")
+    }
+#endif
 
     private func updateCaptureOrientation() {
         let angle = currentVideoRotationAngle()

--- a/LANImageUploader/CameraPicker.swift
+++ b/LANImageUploader/CameraPicker.swift
@@ -252,7 +252,7 @@ struct DocumentPreviewGeometry {
 struct ScannerCaptureView: View {
     let keptPhotoCount: Int
     let scannedPageCount: Int
-    let onScanCapture: (UIImage, DocumentCrop) -> Void
+    let onScanCapture: (UIImage, DocumentCrop?) -> Void
     let onKeepPhoto: (UIImage) -> Void
     let onCountdownTick: () -> Void
     let onOpenGallery: (CameraCaptureMode) -> Void
@@ -272,7 +272,7 @@ struct ScannerCaptureView: View {
         initialMode: CameraCaptureMode,
         keptPhotoCount: Int,
         scannedPageCount: Int,
-        onScanCapture: @escaping (UIImage, DocumentCrop) -> Void,
+        onScanCapture: @escaping (UIImage, DocumentCrop?) -> Void,
         onKeepPhoto: @escaping (UIImage) -> Void,
         onCountdownTick: @escaping () -> Void,
         onOpenGallery: @escaping (CameraCaptureMode) -> Void,
@@ -686,7 +686,7 @@ struct DocumentCameraPreview: UIViewControllerRepresentable {
     @Binding var autoCapture: Bool
     let captureRequest: UUID
     let selectedZoomFactor: CGFloat
-    let onScanCapture: (UIImage, DocumentCrop) -> Void
+    let onScanCapture: (UIImage, DocumentCrop?) -> Void
     let onPhotoCapture: (UIImage) -> Void
     let onDetectionChanged: (String, Bool) -> Void
     let onCountdownChanged: (Int?) -> Void
@@ -761,7 +761,7 @@ final class DocumentCameraViewController: UIViewController, AVCapturePhotoCaptur
             onDetectionChanged?(newValue == .scan ? "Point the camera at a document" : "", false)
         }
     }
-    var onScanCapture: ((UIImage, DocumentCrop) -> Void)?
+    var onScanCapture: ((UIImage, DocumentCrop?) -> Void)?
     var onPhotoCapture: ((UIImage) -> Void)?
     var onDetectionChanged: ((String, Bool) -> Void)?
     var onCountdownChanged: ((Int?) -> Void)?
@@ -1013,7 +1013,7 @@ final class DocumentCameraViewController: UIViewController, AVCapturePhotoCaptur
                             toImageSize: photoSize
                         )
                         .flatMap { $0.isValidForPerspectiveCorrection() ? $0.clamped() : nil }
-                    self.onScanCapture?(upright, crop ?? .fullFrame)
+                    self.onScanCapture?(upright, crop)
                 } else {
                     self.onPhotoCapture?(PhotoCaptureFraming.image(
                         image,

--- a/LANImageUploader/CameraView.swift
+++ b/LANImageUploader/CameraView.swift
@@ -25,7 +25,7 @@ struct CameraView: View {
             scannedPageCount: scannedCount,
             onScanCapture: { image, crop in
                 Task {
-                    await saveImage(image: image, crop: crop)
+                    await saveImage(image: image, crop: crop, isDocumentScan: true)
                 }
             },
             onKeepPhoto: { image in
@@ -62,9 +62,17 @@ struct CameraView: View {
         }
     }
 
-    func saveImage(image: UIImage, crop: DocumentCrop? = nil) async {
+    func saveImage(
+        image: UIImage,
+        crop: DocumentCrop? = nil,
+        isDocumentScan: Bool = false
+    ) async {
         do {
-            try await appData.saveCapturedImage(image, crop: crop)
+            try await appData.saveCapturedImage(
+                image,
+                crop: crop,
+                isDocumentScan: isDocumentScan
+            )
             await MainActor.run {
                 appData.hapticService.playNotification(type: .success)
             }

--- a/LANImageUploader/GalleryModels.swift
+++ b/LANImageUploader/GalleryModels.swift
@@ -347,20 +347,66 @@ enum DocumentImageProcessor {
 
     private static func perspectiveCorrected(_ image: CIImage, crop: DocumentCrop) -> CIImage? {
         let extent = image.extent
-        let normalizedCrop = crop.clamped()
-        func vector(_ point: CGPoint) -> CIVector {
-            CIVector(
-                x: extent.minX + point.x * extent.width,
-                y: extent.minY + (1 - point.y) * extent.height
-            )
+        guard extent.width.isFinite, extent.height.isFinite,
+              extent.width > 1, extent.height > 1,
+              crop.isValidForPerspectiveCorrection() else {
+            return nil
         }
+        let normalizedCrop = crop.clamped()
+        let points = normalizedCrop.coreImagePoints(in: extent)
         guard let filter = CIFilter(name: "CIPerspectiveCorrection") else { return nil }
         filter.setValue(image, forKey: kCIInputImageKey)
-        filter.setValue(vector(normalizedCrop.topLeft), forKey: "inputTopLeft")
-        filter.setValue(vector(normalizedCrop.topRight), forKey: "inputTopRight")
-        filter.setValue(vector(normalizedCrop.bottomRight), forKey: "inputBottomRight")
-        filter.setValue(vector(normalizedCrop.bottomLeft), forKey: "inputBottomLeft")
-        return filter.outputImage
+        filter.setValue(CIVector(cgPoint: points.topLeft), forKey: "inputTopLeft")
+        filter.setValue(CIVector(cgPoint: points.topRight), forKey: "inputTopRight")
+        filter.setValue(CIVector(cgPoint: points.bottomRight), forKey: "inputBottomRight")
+        filter.setValue(CIVector(cgPoint: points.bottomLeft), forKey: "inputBottomLeft")
+        guard let output = filter.outputImage,
+              isPlausible(output.extent, comparedWith: extent),
+              !isMostlyBlack(output) else {
+            return nil
+        }
+        return output
+    }
+
+    private static func isPlausible(_ output: CGRect, comparedWith source: CGRect) -> Bool {
+        guard output.minX.isFinite, output.minY.isFinite,
+              output.width.isFinite, output.height.isFinite,
+              output.width > 1, output.height > 1 else {
+            return false
+        }
+        let areaRatio = (output.width * output.height) / (source.width * source.height)
+        let aspect = output.width / output.height
+        return areaRatio >= 0.01 && areaRatio <= 4
+            && aspect >= 0.1 && aspect <= 10
+            && max(output.width, output.height) <= max(source.width, source.height) * 4
+    }
+
+    private static func isMostlyBlack(_ image: CIImage) -> Bool {
+        let sampleSize = 32
+        guard let cgImage = context.createCGImage(image, from: image.extent) else { return true }
+        var pixels = [UInt8](repeating: 0, count: sampleSize * sampleSize * 4)
+        guard let bitmap = CGContext(
+            data: &pixels,
+            width: sampleSize,
+            height: sampleSize,
+            bitsPerComponent: 8,
+            bytesPerRow: sampleSize * 4,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else {
+            return true
+        }
+        bitmap.interpolationQuality = .low
+        bitmap.draw(cgImage, in: CGRect(x: 0, y: 0, width: sampleSize, height: sampleSize))
+        let blackPixels = stride(from: 0, to: pixels.count, by: 4).reduce(into: 0) { count, index in
+            let luminance = 0.2126 * Double(pixels[index])
+                + 0.7152 * Double(pixels[index + 1])
+                + 0.0722 * Double(pixels[index + 2])
+            if luminance < 8 {
+                count += 1
+            }
+        }
+        return Double(blackPixels) / Double(sampleSize * sampleSize) >= 0.70
     }
 
     private static func applyRotation(to image: CIImage, rotation: ImageRotation) -> CIImage {

--- a/LANImageUploader/GalleryModels.swift
+++ b/LANImageUploader/GalleryModels.swift
@@ -383,21 +383,28 @@ enum DocumentImageProcessor {
 
     private static func isMostlyBlack(_ image: CIImage) -> Bool {
         let sampleSize = 32
-        guard let cgImage = context.createCGImage(image, from: image.extent) else { return true }
-        var pixels = [UInt8](repeating: 0, count: sampleSize * sampleSize * 4)
-        guard let bitmap = CGContext(
-            data: &pixels,
-            width: sampleSize,
-            height: sampleSize,
-            bitsPerComponent: 8,
-            bytesPerRow: sampleSize * 4,
-            space: CGColorSpaceCreateDeviceRGB(),
-            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
-        ) else {
+        let extent = image.extent
+        guard extent.width.isFinite, extent.height.isFinite,
+              extent.width > 0, extent.height > 0 else {
             return true
         }
-        bitmap.interpolationQuality = .low
-        bitmap.draw(cgImage, in: CGRect(x: 0, y: 0, width: sampleSize, height: sampleSize))
+        let translated = image.transformed(by: CGAffineTransform(
+            translationX: -extent.minX,
+            y: -extent.minY
+        ))
+        let sampledImage = translated.transformed(by: CGAffineTransform(
+            scaleX: CGFloat(sampleSize) / extent.width,
+            y: CGFloat(sampleSize) / extent.height
+        ))
+        var pixels = [UInt8](repeating: 0, count: sampleSize * sampleSize * 4)
+        context.render(
+            sampledImage,
+            toBitmap: &pixels,
+            rowBytes: sampleSize * 4,
+            bounds: CGRect(x: 0, y: 0, width: sampleSize, height: sampleSize),
+            format: .RGBA8,
+            colorSpace: CGColorSpaceCreateDeviceRGB()
+        )
         let blackPixels = stride(from: 0, to: pixels.count, by: 4).reduce(into: 0) { count, index in
             let luminance = 0.2126 * Double(pixels[index])
                 + 0.7152 * Double(pixels[index + 1])

--- a/LANImageUploader/GalleryModels.swift
+++ b/LANImageUploader/GalleryModels.swift
@@ -191,10 +191,12 @@ struct DocumentCrop: Codable, Equatable {
         }
         guard crossProducts.allSatisfy({ $0 > 0.0001 }) else { return false }
 
-        let area = zip(ordered, ordered.dropFirst() + [ordered[0]])
-            .reduce(CGFloat.zero) { result, pair in
-                result + pair.0.x * pair.1.y - pair.1.x * pair.0.y
-            } / 2
+        let area = (
+            ordered[0].x * ordered[1].y - ordered[1].x * ordered[0].y
+                + ordered[1].x * ordered[2].y - ordered[2].x * ordered[1].y
+                + ordered[2].x * ordered[3].y - ordered[3].x * ordered[2].y
+                + ordered[3].x * ordered[0].y - ordered[0].x * ordered[3].y
+        ) / 2
         guard area >= minArea else { return false }
 
         func length(_ first: CGPoint, _ second: CGPoint) -> CGFloat {
@@ -406,9 +408,10 @@ enum DocumentImageProcessor {
             colorSpace: CGColorSpaceCreateDeviceRGB()
         )
         let blackPixels = stride(from: 0, to: pixels.count, by: 4).reduce(into: 0) { count, index in
-            let luminance = 0.2126 * Double(pixels[index])
-                + 0.7152 * Double(pixels[index + 1])
-                + 0.0722 * Double(pixels[index + 2])
+            let red = Int(pixels[index])
+            let green = Int(pixels[index + 1])
+            let blue = Int(pixels[index + 2])
+            let luminance = (54 * red + 183 * green + 19 * blue) >> 8
             if luminance < 8 {
                 count += 1
             }

--- a/LANImageUploader/GalleryModels.swift
+++ b/LANImageUploader/GalleryModels.swift
@@ -99,6 +99,13 @@ enum ImageRotation: Int, Codable, CaseIterable {
 }
 
 struct DocumentCrop: Codable, Equatable {
+    struct PixelPoints: Equatable {
+        let topLeft: CGPoint
+        let topRight: CGPoint
+        let bottomRight: CGPoint
+        let bottomLeft: CGPoint
+    }
+
     var topLeft: CGPoint
     var topRight: CGPoint
     var bottomRight: CGPoint
@@ -113,6 +120,125 @@ struct DocumentCrop: Codable, Equatable {
 
     var points: [CGPoint] {
         [topLeft, topRight, bottomRight, bottomLeft]
+    }
+
+    static func visionNormalized(
+        topLeft: CGPoint,
+        topRight: CGPoint,
+        bottomRight: CGPoint,
+        bottomLeft: CGPoint
+    ) -> DocumentCrop {
+        func topLeftOrigin(_ point: CGPoint) -> CGPoint {
+            CGPoint(x: point.x, y: 1 - point.y)
+        }
+        return DocumentCrop(
+            topLeft: topLeftOrigin(topLeft),
+            topRight: topLeftOrigin(topRight),
+            bottomRight: topLeftOrigin(bottomRight),
+            bottomLeft: topLeftOrigin(bottomLeft)
+        )
+    }
+
+    func mapped(fromAspectFillImageSize sourceSize: CGSize, toImageSize targetSize: CGSize) -> DocumentCrop? {
+        guard sourceSize.width > 0, sourceSize.height > 0,
+              targetSize.width > 0, targetSize.height > 0 else {
+            return nil
+        }
+        let sourceAspect = sourceSize.width / sourceSize.height
+        let targetAspect = targetSize.width / targetSize.height
+        let visibleRect: CGRect
+        if sourceAspect < targetAspect {
+            let width = sourceAspect / targetAspect
+            visibleRect = CGRect(x: (1 - width) / 2, y: 0, width: width, height: 1)
+        } else {
+            let height = targetAspect / sourceAspect
+            visibleRect = CGRect(x: 0, y: (1 - height) / 2, width: 1, height: height)
+        }
+        func map(_ point: CGPoint) -> CGPoint {
+            CGPoint(
+                x: visibleRect.minX + point.x * visibleRect.width,
+                y: visibleRect.minY + point.y * visibleRect.height
+            )
+        }
+        return DocumentCrop(
+            topLeft: map(topLeft),
+            topRight: map(topRight),
+            bottomRight: map(bottomRight),
+            bottomLeft: map(bottomLeft)
+        )
+    }
+
+    func isValidForPerspectiveCorrection(
+        minArea: CGFloat = 0.08,
+        minimumEdgeLength: CGFloat = 0.08,
+        boundsEpsilon: CGFloat = 0.002
+    ) -> Bool {
+        guard points.allSatisfy({
+            $0.x.isFinite && $0.y.isFinite
+                && $0.x >= -boundsEpsilon && $0.x <= 1 + boundsEpsilon
+                && $0.y >= -boundsEpsilon && $0.y <= 1 + boundsEpsilon
+        }) else {
+            return false
+        }
+
+        let ordered = points
+        let crossProducts = ordered.indices.map { index -> CGFloat in
+            let first = ordered[index]
+            let second = ordered[(index + 1) % ordered.count]
+            let third = ordered[(index + 2) % ordered.count]
+            return (second.x - first.x) * (third.y - second.y)
+                - (second.y - first.y) * (third.x - second.x)
+        }
+        guard crossProducts.allSatisfy({ $0 > 0.0001 }) else { return false }
+
+        let area = zip(ordered, ordered.dropFirst() + [ordered[0]])
+            .reduce(CGFloat.zero) { result, pair in
+                result + pair.0.x * pair.1.y - pair.1.x * pair.0.y
+            } / 2
+        guard area >= minArea else { return false }
+
+        func length(_ first: CGPoint, _ second: CGPoint) -> CGFloat {
+            hypot(first.x - second.x, first.y - second.y)
+        }
+        let top = length(topLeft, topRight)
+        let right = length(topRight, bottomRight)
+        let bottom = length(bottomRight, bottomLeft)
+        let left = length(bottomLeft, topLeft)
+        guard min(top, right, bottom, left) >= minimumEdgeLength else { return false }
+        guard max(top, bottom) / min(top, bottom) < 3,
+              max(left, right) / min(left, right) < 3 else {
+            return false
+        }
+
+        let bounds = boundingRect
+        let aspect = bounds.width / bounds.height
+        return aspect.isFinite && aspect >= 0.2 && aspect <= 5
+    }
+
+    func coreImagePoints(in extent: CGRect) -> PixelPoints {
+        func map(_ point: CGPoint) -> CGPoint {
+            CGPoint(
+                x: extent.minX + point.x * extent.width,
+                y: extent.minY + (1 - point.y) * extent.height
+            )
+        }
+        return PixelPoints(
+            topLeft: map(topLeft),
+            topRight: map(topRight),
+            bottomRight: map(bottomRight),
+            bottomLeft: map(bottomLeft)
+        )
+    }
+
+    private var boundingRect: CGRect {
+        let xs = points.map(\.x)
+        let ys = points.map(\.y)
+        return CGRect(
+            x: xs.min() ?? 0,
+            y: ys.min() ?? 0,
+            width: (xs.max() ?? 0) - (xs.min() ?? 0),
+            height: (ys.max() ?? 0) - (ys.min() ?? 0)
+        )
     }
 
     func clamped() -> DocumentCrop {

--- a/LANImageUploaderTests/LANImageUploaderTests.swift
+++ b/LANImageUploaderTests/LANImageUploaderTests.swift
@@ -8,6 +8,7 @@
 import Testing
 import Foundation
 import UIKit
+import ImageIO
 @testable import LANImageUploader
 
 private final class ProgressRecorder: @unchecked Sendable {
@@ -32,6 +33,105 @@ struct LANImageUploaderTests {
     @Test func scannerCapturePolicyNeverConfiguresOrCapturesAudio() {
         #expect(!ScannerCapturePolicy.automaticallyConfiguresApplicationAudioSession)
         #expect(!ScannerCapturePolicy.includesAudioInput)
+    }
+
+    @Test func visionRectangleConvertsToTopLeftCoordinates() {
+        let crop = DocumentCrop.visionNormalized(
+            topLeft: CGPoint(x: 0.1, y: 0.9),
+            topRight: CGPoint(x: 0.9, y: 0.9),
+            bottomRight: CGPoint(x: 0.9, y: 0.2),
+            bottomLeft: CGPoint(x: 0.1, y: 0.2)
+        )
+
+        #expect(crop.topLeft == CGPoint(x: 0.1, y: 0.1))
+        #expect(crop.topRight == CGPoint(x: 0.9, y: 0.1))
+        #expect(crop.bottomRight == CGPoint(x: 0.9, y: 0.8))
+        #expect(crop.bottomLeft == CGPoint(x: 0.1, y: 0.8))
+    }
+
+    @Test func cropMapsBetweenAspectFillVideoAndPhotoCoordinates() throws {
+        let detected = DocumentCrop(
+            topLeft: CGPoint(x: 0.1, y: 0.1),
+            topRight: CGPoint(x: 0.9, y: 0.1),
+            bottomRight: CGPoint(x: 0.9, y: 0.9),
+            bottomLeft: CGPoint(x: 0.1, y: 0.9)
+        )
+
+        let portrait = try #require(detected.mapped(
+            fromAspectFillImageSize: CGSize(width: 1080, height: 1920),
+            toImageSize: CGSize(width: 3024, height: 4032)
+        ))
+        #expect(abs(portrait.topLeft.x - 0.2) < 0.001)
+        #expect(abs(portrait.topRight.x - 0.8) < 0.001)
+        #expect(abs(portrait.topLeft.y - 0.1) < 0.001)
+
+        let landscape = try #require(detected.mapped(
+            fromAspectFillImageSize: CGSize(width: 1920, height: 1080),
+            toImageSize: CGSize(width: 4032, height: 3024)
+        ))
+        #expect(abs(landscape.topLeft.x - 0.1) < 0.001)
+        #expect(abs(landscape.topLeft.y - 0.2) < 0.001)
+        #expect(abs(landscape.bottomLeft.y - 0.8) < 0.001)
+    }
+
+    @Test func documentCropValidationRejectsUnsafeGeometry() {
+        let valid = DocumentCrop(
+            topLeft: CGPoint(x: 0.12, y: 0.08),
+            topRight: CGPoint(x: 0.88, y: 0.1),
+            bottomRight: CGPoint(x: 0.84, y: 0.92),
+            bottomLeft: CGPoint(x: 0.16, y: 0.9)
+        )
+        let tiny = DocumentCrop(
+            topLeft: CGPoint(x: 0.45, y: 0.45),
+            topRight: CGPoint(x: 0.55, y: 0.45),
+            bottomRight: CGPoint(x: 0.55, y: 0.55),
+            bottomLeft: CGPoint(x: 0.45, y: 0.55)
+        )
+        let crossing = DocumentCrop(
+            topLeft: CGPoint(x: 0.1, y: 0.1),
+            topRight: CGPoint(x: 0.9, y: 0.9),
+            bottomRight: CGPoint(x: 0.9, y: 0.1),
+            bottomLeft: CGPoint(x: 0.1, y: 0.9)
+        )
+        let outside = DocumentCrop(
+            topLeft: CGPoint(x: -0.2, y: 0.1),
+            topRight: CGPoint(x: 0.9, y: 0.1),
+            bottomRight: CGPoint(x: 0.9, y: 0.9),
+            bottomLeft: CGPoint(x: 0.1, y: 0.9)
+        )
+        let flat = DocumentCrop(
+            topLeft: CGPoint(x: 0.1, y: 0.48),
+            topRight: CGPoint(x: 0.9, y: 0.48),
+            bottomRight: CGPoint(x: 0.9, y: 0.52),
+            bottomLeft: CGPoint(x: 0.1, y: 0.52)
+        )
+
+        #expect(valid.isValidForPerspectiveCorrection())
+        #expect(!tiny.isValidForPerspectiveCorrection())
+        #expect(!crossing.isValidForPerspectiveCorrection())
+        #expect(!outside.isValidForPerspectiveCorrection())
+        #expect(!flat.isValidForPerspectiveCorrection())
+    }
+
+    @Test func fullFrameCropMapsToCoreImageExtent() {
+        let extent = CGRect(x: 20, y: 40, width: 1200, height: 1600)
+        let points = DocumentCrop.fullFrame.coreImagePoints(in: extent)
+
+        #expect(points.topLeft == CGPoint(x: 20, y: 1640))
+        #expect(points.topRight == CGPoint(x: 1220, y: 1640))
+        #expect(points.bottomRight == CGPoint(x: 1220, y: 40))
+        #expect(points.bottomLeft == CGPoint(x: 20, y: 40))
+    }
+
+    @Test func visionOrientationMatchesCaptureRotationAngle() {
+        #expect(DocumentCaptureOrientation.visionOrientation(forVideoRotationAngle: 0) == .up)
+        #expect(DocumentCaptureOrientation.visionOrientation(forVideoRotationAngle: 90) == .right)
+        #expect(DocumentCaptureOrientation.visionOrientation(forVideoRotationAngle: 180) == .down)
+        #expect(DocumentCaptureOrientation.visionOrientation(forVideoRotationAngle: 270) == .left)
+        #expect(DocumentCaptureOrientation.orientedSize(
+            CGSize(width: 1920, height: 1080),
+            orientation: .right
+        ) == CGSize(width: 1080, height: 1920))
     }
 
     @Test func onboardingCoversTheApprovedFourChapterFlow() {

--- a/LANImageUploaderTests/LANImageUploaderTests.swift
+++ b/LANImageUploaderTests/LANImageUploaderTests.swift
@@ -316,6 +316,34 @@ struct LANImageUploaderTests {
         #expect(appData.images.map { $0.name } == ["IMG_20260515_101112"])
     }
 
+    @Test func capturedImageTimestampFormatterIsDeterministicAndThreadSafe() async throws {
+        var components = DateComponents()
+        components.calendar = Calendar(identifier: .gregorian)
+        components.timeZone = TimeZone(secondsFromGMT: 0)
+        components.year = 2026
+        components.month = 5
+        components.day = 15
+        components.hour = 10
+        components.minute = 11
+        components.second = 12
+        let date = try #require(components.date)
+
+        let timestamps = await withTaskGroup(of: String.self, returning: [String].self) { group in
+            for _ in 0..<32 {
+                group.addTask {
+                    CapturedImageTimestampFormatter.shared.string(
+                        from: date,
+                        timeZone: TimeZone(secondsFromGMT: 0)!
+                    )
+                }
+            }
+            return await group.reduce(into: []) { $0.append($1) }
+        }
+
+        #expect(timestamps.count == 32)
+        #expect(timestamps.allSatisfy { $0 == "20260515_101112" })
+    }
+
     @Test @MainActor func cameraSaveImageFailureDoesNotAppendGalleryItem() async throws {
         let mockFile = MockFileService()
         mockFile.saveImageError = NSError(domain: "test", code: 2)

--- a/LANImageUploaderTests/LANImageUploaderTests.swift
+++ b/LANImageUploaderTests/LANImageUploaderTests.swift
@@ -43,10 +43,14 @@ struct LANImageUploaderTests {
             bottomLeft: CGPoint(x: 0.1, y: 0.2)
         )
 
-        #expect(crop.topLeft == CGPoint(x: 0.1, y: 0.1))
-        #expect(crop.topRight == CGPoint(x: 0.9, y: 0.1))
-        #expect(crop.bottomRight == CGPoint(x: 0.9, y: 0.8))
-        #expect(crop.bottomLeft == CGPoint(x: 0.1, y: 0.8))
+        #expect(abs(crop.topLeft.x - 0.1) < 0.0001)
+        #expect(abs(crop.topLeft.y - 0.1) < 0.0001)
+        #expect(abs(crop.topRight.x - 0.9) < 0.0001)
+        #expect(abs(crop.topRight.y - 0.1) < 0.0001)
+        #expect(abs(crop.bottomRight.x - 0.9) < 0.0001)
+        #expect(abs(crop.bottomRight.y - 0.8) < 0.0001)
+        #expect(abs(crop.bottomLeft.x - 0.1) < 0.0001)
+        #expect(abs(crop.bottomLeft.y - 0.8) < 0.0001)
     }
 
     @Test func cropMapsBetweenAspectFillVideoAndPhotoCoordinates() throws {
@@ -132,6 +136,76 @@ struct LANImageUploaderTests {
             CGSize(width: 1920, height: 1080),
             orientation: .right
         ) == CGSize(width: 1080, height: 1920))
+    }
+
+    @Test @MainActor func invalidPerspectiveCropFallsBackToOriginalImage() throws {
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = 1
+        let source = UIGraphicsImageRenderer(
+            size: CGSize(width: 200, height: 300),
+            format: format
+        ).image { context in
+            UIColor.white.setFill()
+            context.fill(CGRect(x: 0, y: 0, width: 200, height: 300))
+        }
+        let crossing = DocumentCrop(
+            topLeft: CGPoint(x: 0.1, y: 0.1),
+            topRight: CGPoint(x: 0.9, y: 0.9),
+            bottomRight: CGPoint(x: 0.9, y: 0.1),
+            bottomLeft: CGPoint(x: 0.1, y: 0.9)
+        )
+
+        let rendered = DocumentImageProcessor.renderedImage(source, crop: crossing)
+
+        #expect(rendered.size == source.size)
+    }
+
+    @Test @MainActor func validPerspectiveCropProducesNonBlackImage() throws {
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = 1
+        let source = UIGraphicsImageRenderer(
+            size: CGSize(width: 240, height: 320),
+            format: format
+        ).image { context in
+            UIColor.white.setFill()
+            context.fill(CGRect(x: 0, y: 0, width: 240, height: 320))
+            UIColor.black.setStroke()
+            context.cgContext.setLineWidth(4)
+            context.stroke(CGRect(x: 30, y: 25, width: 180, height: 270))
+        }
+        let crop = DocumentCrop(
+            topLeft: CGPoint(x: 0.12, y: 0.08),
+            topRight: CGPoint(x: 0.88, y: 0.08),
+            bottomRight: CGPoint(x: 0.88, y: 0.92),
+            bottomLeft: CGPoint(x: 0.12, y: 0.92)
+        )
+
+        let rendered = DocumentImageProcessor.renderedImage(source, crop: crop)
+
+        #expect(rendered.size.width > 0)
+        #expect(rendered.size.height > 0)
+        #expect(try Self.centerBrightness(of: rendered) > 0.9)
+    }
+
+    @Test @MainActor func scanWithoutConfidentCropRemainsDocumentScan() async throws {
+        let mockFile = MockFileService()
+        mockFile.saveImageResult = URL(fileURLWithPath: "/tmp/mock/images/scan.jpg")
+        let appData = AppData(
+            fileService: mockFile,
+            uploadService: MockImageUploadService(),
+            discoveryService: MockNetworkDiscovery(),
+            hapticService: MockHapticFeedbackService()
+        )
+        let image = try #require(Self.makeImage())
+
+        let captured = try await appData.saveCapturedImage(
+            image,
+            crop: nil,
+            isDocumentScan: true
+        )
+
+        #expect(captured.crop == nil)
+        #expect(captured.isDocumentScan)
     }
 
     @Test func onboardingCoversTheApprovedFourChapterFlow() {
@@ -796,6 +870,28 @@ struct LANImageUploaderTests {
             }
             context.cgContext.strokePath()
         }
+    }
+
+    private static func centerBrightness(of image: UIImage) throws -> CGFloat {
+        let cgImage = try #require(image.cgImage)
+        let x = cgImage.width / 2
+        let y = cgImage.height / 2
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        var pixel = [UInt8](repeating: 0, count: 4)
+        let context = try #require(CGContext(
+            data: &pixel,
+            width: 1,
+            height: 1,
+            bitsPerComponent: 8,
+            bytesPerRow: 4,
+            space: colorSpace,
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ))
+        context.draw(
+            cgImage,
+            in: CGRect(x: -x, y: y - cgImage.height, width: cgImage.width, height: cgImage.height)
+        )
+        return (CGFloat(pixel[0]) + CGFloat(pixel[1]) + CGFloat(pixel[2])) / (3 * 255)
     }
 }
 

--- a/LANImageUploaderTests/LANImageUploaderTests.swift
+++ b/LANImageUploaderTests/LANImageUploaderTests.swift
@@ -29,6 +29,11 @@ private final class ProgressRecorder: @unchecked Sendable {
 
 struct LANImageUploaderTests {
 
+    @Test func scannerCapturePolicyNeverConfiguresOrCapturesAudio() {
+        #expect(!ScannerCapturePolicy.automaticallyConfiguresApplicationAudioSession)
+        #expect(!ScannerCapturePolicy.includesAudioInput)
+    }
+
     @Test func onboardingCoversTheApprovedFourChapterFlow() {
         #expect(OnboardingPage.allCases == [.privacy, .capture, .organize, .ready])
         #expect(OnboardingPage.capture.message.localizedCaseInsensitiveContains("multi-page"))

--- a/docs/superpowers/plans/2026-06-10-scanner-audio-crop.md
+++ b/docs/superpowers/plans/2026-06-10-scanner-audio-crop.md
@@ -1,0 +1,70 @@
+# Scanner Audio Preservation and Crop Reliability Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Preserve external audio during camera use and make document crop coordinates reliable across video detection, still capture, Gallery, JPEG, and PDF rendering.
+
+**Architecture:** Keep `DocumentCrop` as top-left normalized coordinates in the upright saved image. Capture orientation and source geometry with each Vision result, transform it into the upright photo coordinate system, validate it, and make rendering fail closed to the original image.
+
+**Tech Stack:** Swift, SwiftUI, AVFoundation, Vision, Core Image, Swift Testing, Xcode.
+
+---
+
+### Task 1: Audio-Safe Camera Configuration
+
+**Files:**
+- Modify: `LANImageUploader/CameraPicker.swift`
+- Test: `LANImageUploaderTests/GalleryModelsTests.swift`
+
+- [ ] Add a failing unit test for a `ScannerCapturePolicy` whose automatic audio-session configuration and audio capture flags are both false.
+- [ ] Run the focused test and verify it fails because the policy does not exist.
+- [ ] Add the policy, set `session.automaticallyConfiguresApplicationAudioSession = false`, and assert that only a video input is created.
+- [ ] Set the legacy image picker to `public.image` and `.photo`.
+- [ ] Add DEBUG-only interruption and route-change observers with privacy-safe logging.
+- [ ] Run the focused tests and build.
+- [ ] Commit the audio-only change.
+
+### Task 2: Canonical Crop Geometry
+
+**Files:**
+- Modify: `LANImageUploader/GalleryModels.swift`
+- Modify: `LANImageUploader/CameraPicker.swift`
+- Test: `LANImageUploaderTests/GalleryModelsTests.swift`
+
+- [ ] Add failing tests for Vision conversion, portrait/landscape aspect mapping, valid A4 geometry, tiny crops, crossing points, out-of-bounds points, and flat/skewed crops.
+- [ ] Run focused tests and verify the new tests fail.
+- [ ] Implement canonical coordinate conversion, aspect-fill mapping, and robust validation in `DocumentCrop`.
+- [ ] Replace hardcoded Vision `.up` with interface-orientation-derived `CGImagePropertyOrientation`.
+- [ ] Store detection orientation, image size, and an orientation generation with the latest crop.
+- [ ] Normalize still photos upright and transform only current, valid crop metadata into still-image coordinates.
+- [ ] Clear detections on orientation changes.
+- [ ] Run focused tests and commit the coordinate pipeline.
+
+### Task 3: Rendering Guardrails and Scan Classification
+
+**Files:**
+- Modify: `LANImageUploader/GalleryModels.swift`
+- Modify: `LANImageUploader/CameraPicker.swift`
+- Modify: `LANImageUploader/CameraView.swift`
+- Modify: `LANImageUploader/AppData.swift`
+- Test: `LANImageUploaderTests/GalleryModelsTests.swift`
+
+- [ ] Add failing tests that invalid perspective crops return original dimensions/content and valid crops return non-empty, non-black output.
+- [ ] Add a failing test proving a document scan can remain classified as a scan when crop metadata is nil.
+- [ ] Run focused tests and verify failures.
+- [ ] Validate Core Image input vectors and output extent before rendering.
+- [ ] Detect implausibly black corrected output using a bounded render and fall back to the source.
+- [ ] Change scan capture callback to accept an optional crop and save scans with explicit `isDocumentScan`.
+- [ ] Run focused tests and commit guardrails.
+
+### Task 4: Verification and PR
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-06-10-scanner-audio-crop.md`
+
+- [ ] Run the full unit test suite on `LANImageUploader iPhone 17 Pro` with iOS 26.5.
+- [ ] Run a clean simulator build.
+- [ ] Inspect the final diff for credentials, patient data, microphone usage descriptions, audio inputs, and unrelated changes.
+- [ ] Mark completed plan steps.
+- [ ] Push the branch and open a draft PR with root causes, exact fixes, automated verification, and an explicit real-device QA checklist.
+- [ ] Do not claim real-device audio or camera acceptance criteria are complete unless physically tested.

--- a/docs/superpowers/specs/2026-06-10-scanner-audio-crop-design.md
+++ b/docs/superpowers/specs/2026-06-10-scanner-audio-crop-design.md
@@ -1,0 +1,57 @@
+# Scanner Audio Preservation and Crop Reliability Design
+
+## Goal
+
+Keep external audio playing throughout ImageDrop camera and scanner use, and ensure document scans never render as a small valid region surrounded by black output.
+
+## Root-Cause Model
+
+The repository contains no explicit `AVAudioSession` category or activation calls. The custom `AVCaptureSession` therefore retains its default ability to configure the application audio session. The legacy `UIImagePickerController` also does not explicitly restrict capture to still images.
+
+Rectangle detection runs against `AVCaptureVideoDataOutput` buffers while the saved image comes from `AVCapturePhotoOutput`. The current code passes Vision a hardcoded `.up` orientation and stores the resulting normalized points directly against the still image. Video and photo outputs can differ in orientation and aspect ratio, so those points are not guaranteed to describe the same pixels. Crop processing also clamps malformed points and trusts any Core Image output, allowing invalid geometry to become a mostly black image.
+
+## Audio Design
+
+- Set `AVCaptureSession.automaticallyConfiguresApplicationAudioSession` to `false` before configuring or starting the custom session.
+- Add only a `.video` camera device input. Do not create an audio input, activate `AVAudioSession`, or request microphone access.
+- Configure `UIImagePickerController` with `mediaTypes = ["public.image"]` and `cameraCaptureMode = .photo`.
+- Add DEBUG-only observers for audio interruption and route-change notifications. Log only notification type/reason and remove observers when the controller is released.
+- Keep audio policy as a small testable value describing that automatic session configuration and audio capture are disabled.
+
+## Crop Coordinate Design
+
+`DocumentCrop` is normalized `0...1` in the upright saved image, with a top-left origin and points ordered clockwise:
+
+`topLeft -> topRight -> bottomRight -> bottomLeft`.
+
+Vision observations are converted from lower-left coordinates to this canonical top-left system. Detection records the orientation and oriented sample-buffer aspect ratio with each crop. At photo completion, the photo is normalized to upright pixels. The crop is mapped between the oriented detection image and upright still image using their aspect-fill relationship, matching the shared camera field of view. The mapped crop is stored only when its orientation generation still matches the capture and its geometry validates.
+
+Orientation changes clear the latest detection so a crop from the previous orientation cannot be reused.
+
+## Validation and Fallback
+
+Crop validation rejects:
+
+- non-finite or materially out-of-bounds points;
+- incorrect clockwise ordering or self-intersection;
+- area below the configured threshold;
+- very short edges or flat quadrilaterals;
+- extreme opposing-edge asymmetry or implausible aspect ratio.
+
+Invalid capture geometry is reported as `crop = nil`; the original upright image is saved as a document scan. `CapturedImage.isDocumentScan` is therefore passed explicitly rather than inferred only from crop presence.
+
+`DocumentImageProcessor` validates geometry before perspective correction and validates the resulting extent. It renders a bounded preview to estimate near-black coverage. Empty, non-finite, excessively large, implausibly shaped, or mostly black results fall back to the original image. Gallery thumbnails, fullscreen previews, JPEG exports, and PDF generation already use this processor and therefore share the fallback.
+
+## Testing
+
+- Unit-test Vision lower-left to canonical top-left conversion.
+- Unit-test orientation and aspect-fill mapping for portrait and landscape.
+- Unit-test crop validation for normal, tiny, out-of-bounds, crossing, flat, and highly skewed quadrilaterals.
+- Unit-test normalized-to-Core-Image pixel mapping.
+- Unit-test perspective-correction fallback and valid non-black output.
+- Unit-test the scanner audio policy and explicit scan classification without crop metadata.
+- Build and run the full test suite on the configured iOS simulator.
+
+## Manual QA Boundary
+
+Simulator tests cannot prove that Music, Podcasts, Spotify, or Audible continue on a physical device, and simulator camera input cannot fully reproduce live portrait/landscape document detection. The PR must clearly mark real-device audio and scan-orientation checks as required and must not claim those acceptance criteria are complete until performed.


### PR DESCRIPTION
## Summary

- Preserve background audio by preventing the scanner capture session from configuring the application audio session.
- Map Vision rectangle detections from the oriented video buffer into the upright still-photo coordinate space.
- Reject stale or unsafe crop geometry and fall back to the original scan when correction is invalid or mostly black.

## Root causes

### Background audio

The app did not explicitly configure `AVAudioSession`, but the custom `AVCaptureSession` retained its default ability to configure the application audio session. The legacy `UIImagePickerController` path was also not explicitly constrained to still images.

### Broken document crop

Vision was always invoked with orientation `.up`, while preview and photo connections used rotation angles. The detected normalized rectangle came from the video output and was then applied directly to a still photo with a different orientation and aspect ratio. Invalid geometry was clamped and passed to `CIPerspectiveCorrection` without validating the resulting canvas or content.

## Changes

- Set `automaticallyConfiguresApplicationAudioSession = false` before capture-session configuration.
- Keep the capture graph video-only and assert in DEBUG that no audio port exists.
- Restrict the legacy picker to `public.image` and `.photo`.
- Add DEBUG-only, privacy-safe audio interruption and route-change diagnostics.
- Define `DocumentCrop` as normalized top-left coordinates in the upright saved image.
- Derive the Vision orientation from the active capture rotation.
- Track orientation generations and discard stale rectangle detections after rotation.
- Map the oriented video rectangle through the aspect-fill field of view into upright still-photo coordinates.
- Validate bounds, point order, area, edge lengths, skew, and aspect before perspective correction.
- Validate Core Image output extent and reject mostly-black corrected output.
- Save low-confidence scans as full upright document scans with `crop = nil`; Gallery retains the existing Edit Crop path.
- Keep Gallery, JPEG export, and PDF generation on the shared guarded `DocumentImageProcessor` path.

## Automated verification

- `xcodebuild test ... -only-testing:LANImageUploaderTests` passed on `LANImageUploader iPhone 17 Pro`, iOS 26.5.
- `xcodebuild build ...` passed on the same simulator.
- Added tests for audio capture policy, Vision coordinate conversion, portrait/landscape aspect mapping, crop validation, Core Image point mapping, orientation mapping, perspective fallback, non-black valid output, and document classification without crop metadata.
- Full-scheme testing also attempted; the template UI test runner hit the repository’s known simulator launch failure.

## Required real-device QA before declaring fixed

- Play Music/Spotify and Podcasts/Audible while launching the app, opening Camera, switching Photo/Scan, auto-scanning, manually scanning, opening Gallery, and uploading/cancelling.
- Confirm no microphone permission prompt appears.
- Scan A4 pages in portrait, landscape left, and landscape right, including skewed and edge-of-frame pages.
- Confirm Gallery, exported JPG, and PDF match the detected rectangle and never contain a mostly-black canvas.

This PR remains draft because real-device audio continuity and live camera orientation acceptance criteria have not yet been verified.
