### PR TITLE
[codex] Fix legacy PDF viewer compatibility

### DIFF
--- a/.github/workflows/antigravity-review.yml
+++ b/.github/workflows/antigravity-review.yml
@@ -1,0 +1,119 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: '🔎 Antigravity Code Review'
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      pull_request_number:
+        description: 'Pull Request number to review (optional, auto-detected if omitted)'
+        required: false
+        type: string
+      additional_context:
+        description: 'Additional context or instructions for this run'
+        required: false
+        type: string
+
+# Concurrency group ensures concurrent runs on the same PR/branch cancel previous runs
+concurrency:
+  group: '${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}'
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  review:
+    name: 'Antigravity Code Review'
+    # Security gates:
+    # 1. Block PRs originating from forks (forks don't have access to secrets anyway).
+    # 2. For comments, trigger only on PR comments containing the exact command from a maintainer.
+    if: |
+      (github.event_name == 'workflow_dispatch') ||
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request != null &&
+       (github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR') &&
+       contains(github.event.comment.body, '@agy /review'))
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+
+    steps:
+      - name: 'Determine Pull Request Number'
+        id: determine_pr
+        run: |
+          PR_NUMBER=""
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            PR_NUMBER="${{ github.event.pull_request.number }}"
+          elif [ "${{ github.event_name }}" = "issue_comment" ]; then
+            PR_NUMBER="${{ github.event.issue.number }}"
+          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            PR_NUMBER="${{ github.event.inputs.pull_request_number }}"
+            if [ -z "$PR_NUMBER" ]; then
+              echo "Attempting to auto-detect Pull Request number for branch ${{ github.ref_name }}..."
+              PR_NUMBER=$(gh pr list --repo "${{ github.repository }}" --head "${{ github.ref_name }}" --json number --jq '.[0].number' || true)
+            fi
+          fi
+
+          if [ -z "$PR_NUMBER" ]; then
+            echo "Error: Could not determine Pull Request number."
+            exit 1
+          fi
+          echo "pr_number=${PR_NUMBER}" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 'Checkout Repository'
+        uses: actions/checkout@v4
+        with:
+          # Check out the merge ref of the PR so the agent sees the proposed changes merged with target branch
+          ref: refs/pull/${{ steps.determine_pr.outputs.pr_number }}/merge
+          persist-credentials: false
+
+      - name: 'Run Antigravity PR Review'
+        uses: rsamborski/run-agy-sdk@da0ff77fc9dfc82e5ad89a430bc51476aeb8f867 # Pinned to commit da0ff77 on 2026-06-19
+        env:
+          # Additional context to pass to the agent
+          ADDITIONAL_CONTEXT: '${{ github.event.inputs.additional_context || github.event.comment.body }}'
+        with:
+          api-key: '${{ secrets.ANTIGRAVITY_API_KEY }}'
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+          mode: 'review'
+          sandbox-profile: 'true'
+          trust-workspace: 'true'
+          prompt: |
+            You are acting as a Senior Staff Engineer. Conduct a rigorous review of the changes in this Pull Request.
+            
+            Your analysis must focus on:
+            1. Architecture & Design: Is the change clean, modular, and does it respect local-first patterns?
+            2. Bugs & Correctness: Find logical flaws, memory management issues (especially in SwiftUI/Combine/Swift concurrency), or resource leaks.
+            3. Security & Privacy: No credentials in logs, respect PII/PHI privacy, secure Keychain use, no cloud/analytics without approval.
+            4. Best Practices: Follow Apple HIG, SwiftUI performance, error handling, minimal dependencies.
+            5. Suggested Fixes: Propose concrete refactorings or diffs for identified problems.
+            
+            Refer to the instructions in the project root file CODE-REVIEW.md for details of our review rubric.

--- a/CODE-REVIEW.md
+++ b/CODE-REVIEW.md
@@ -1,0 +1,48 @@
+# LANImageUploader (ImageDrop) Code Review Rubric
+
+This document serves as the authoritative code review rubric for all automated and manual code reviews. When reviewing Pull Requests, evaluate changes against these guidelines.
+
+---
+
+## 1. Core Architecture & Local-First Philosophy
+*   **Local-First Storage:** All images and archives must remain fully on-device. No cloud storage sync or external communication is permitted without explicit, documented architectural approval.
+*   **State Management:** `AppData` is the single source of truth for the entire application. It must be passed via `.environmentObject` in the view hierarchy. Never instantiate multiple copies or bypass this container.
+*   **Directory Structure:**
+    *   Active/captured images must be stored under `Documents/images/`.
+    *   Archived images must be grouped by date under `Documents/YYYY-MM-DD/`.
+    *   Any changes to this structure require a documented, safe migration plan.
+
+---
+
+## 2. Security & Data Privacy
+*   **Credential Handling:** 
+    *   All sensitive credentials (e.g., SMB passwords, tokens) **must** be stored securely in the iOS Keychain.
+    *   Only non-sensitive configurations (e.g., server IP, share names, username) may be stored in `UserDefaults`.
+*   **Logging Constraints:**
+    *   Never log or print passwords, auth tokens, or keys.
+    *   Do not log personally identifiable information (PII), local IP addresses, share names, or specific directory paths in production logs.
+*   **Networking Sandbox:** All network transfers must be performed over local networks (LAN) using `AMSMB2`. Maintain minimal network privileges.
+
+---
+
+## 3. Local Networking & SMB Connections
+*   **SMB Protocol Integration:** Use the standard `AMSMB2` package for all SMB shares. Do not introduce other network file transfer libraries.
+*   **Resource Lifecycle:** Always disconnect from the SMB share immediately after completing transfer or discovery tasks. Connection handles must not be kept open indefinitely.
+*   **Discovery:** Rely exclusively on `NetworkDiscovery` and `NetworkMonitor` for scanning/tracking network state and auto-discovering local SMB shares via Bonjour.
+
+---
+
+## 4. SwiftUI & User Interface (Apple HIG)
+*   **Theme Consistency:** Cohesive dark/gradient styling is a core product requirement. Wrap screen components inside `BackgroundContainerView` or utilize `AppBackground` to preserve the visual theme.
+*   **Button Design:** Interactive buttons must leverage the styles defined in `ButtonStyles.swift`. Do not define ad-hoc button styles.
+*   **Navigation:** Prefer standard `NavigationStack` with `navigationDestination(for:)` for transitions.
+*   **Thread Safety:** Long-running/intensive I/O operations (file writing, network calls) must run asynchronously off the main thread. Ensure all UI updates are dispatched on the `@MainActor`.
+
+---
+
+## 5. Dependency & Project Management
+*   **Minimal Dependencies:** Do not introduce third-party Swift packages or CocoaPods unless explicitly approved. Maximize standard Apple framework APIs (SwiftUI, Network, Security, etc.).
+*   **Project File Integrity (`.pbxproj`):**
+    *   Do not let automated scripts modify `.xcodeproj/project.pbxproj`.
+    *   Ensure any new files created are added to Xcode target groups manually or via verified tooling.
+*   **App Configuration:** Do not alter the Bundle Identifier, entitlements, background task configurations, or code signing profiles.

--- a/LANImageUploader/CameraView.swift
+++ b/LANImageUploader/CameraView.swift
@@ -7,14 +7,22 @@
 
 import SwiftUI
 
+struct CameraGalleryRoute: Identifiable {
+    let id = UUID()
+    let outputMode: GalleryOutputMode
+
+    init(captureMode: CameraCaptureMode) {
+        outputMode = captureMode == .scan ? .singlePDF : .separateImages
+    }
+}
+
 struct CameraView: View {
     let initialMode: CameraCaptureMode
     @State private var showError = false
     @State private var errorMessage = ""
     @EnvironmentObject var appData: AppData
     @Environment(\.dismiss) var dismiss
-    @State private var navigateToGallery = false
-    @State private var galleryOutputMode: GalleryOutputMode?
+    @State private var galleryRoute: CameraGalleryRoute?
 
     var body: some View {
         let scannedCount = appData.images.filter(\.isDocumentScan).count
@@ -37,8 +45,7 @@ struct CameraView: View {
                 appData.hapticService.playImpact(style: .medium)
             },
             onOpenGallery: { mode in
-                galleryOutputMode = mode == .scan ? .singlePDF : .separateImages
-                navigateToGallery = true
+                galleryRoute = CameraGalleryRoute(captureMode: mode)
             },
             onCancel: { dismiss() }
         )
@@ -47,14 +54,14 @@ struct CameraView: View {
         } message: {
             Text(errorMessage)
         }
-        .fullScreenCover(isPresented: $navigateToGallery) {
+        .fullScreenCover(item: $galleryRoute) { route in
             NavigationStack {
-                GalleryView(initialOutputMode: galleryOutputMode)
+                GalleryView(initialOutputMode: route.outputMode)
                     .environmentObject(appData)
                     .toolbar {
                         ToolbarItem(placement: .cancellationAction) {
                             Button("Close") {
-                                navigateToGallery = false
+                                galleryRoute = nil
                             }
                         }
                     }

--- a/LANImageUploader/Services/PDFGenerationService.swift
+++ b/LANImageUploader/Services/PDFGenerationService.swift
@@ -114,16 +114,23 @@ private enum LegacyPDFWriter {
                 commands += "BT /F1 10 Tf \(x) \(max(8, pageRect.height - r.maxY - 18)) Td (\(number)) Tj ET\n"
             }
             let content = ascii(commands)
-            var stream = ascii("<< /Length \(content.count) >>\nstream\n"); stream.append(content); stream.append(ascii("endstream")); objects.append(stream)
+            var stream = ascii("<< /Length \(content.count) >>\nstream\n")
+            stream.append(content)
+            stream.append(ascii("\nendstream"))
+            objects.append(stream)
         }
-        var result = ascii("%PDF-1.3\n%\u{00E2}\u{00E3}\u{00CF}\u{00D3}\n")
+        var result = ascii("%PDF-1.3\n%")
+        result.append(contentsOf: [0xE2, 0xE3, 0xCF, 0xD3])
+        result.append(ascii("\n"))
         var offsets = [0]
         for (index, object) in objects.enumerated() {
             offsets.append(result.count); result.append(ascii("\(index + 1) 0 obj\n")); result.append(object); result.append(ascii("\nendobj\n"))
         }
         let xref = result.count
         result.append(ascii("xref\n0 \(objects.count + 1)\n0000000000 65535 f \n"))
-        for offset in offsets.dropFirst() { result.append(ascii(String(format: "%010d 00000 n \n", offset))) }
+        for offset in offsets.dropFirst() {
+            result.append(ascii(String(format: "%010d 00000 n \n", locale: Locale(identifier: "en_US_POSIX"), offset)))
+        }
         result.append(ascii("trailer\n<< /Size \(objects.count + 1) /Root 1 0 R >>\nstartxref\n\(xref)\n%%EOF\n"))
         try result.write(to: url, options: .atomic)
     }

--- a/LANImageUploader/Services/PDFGenerationService.swift
+++ b/LANImageUploader/Services/PDFGenerationService.swift
@@ -5,7 +5,6 @@
 
 import Foundation
 import UIKit
-import PDFKit
 
 final class PDFGenerationService: PDFGenerationServiceProtocol {
     static let shared = PDFGenerationService()
@@ -36,35 +35,26 @@ final class PDFGenerationService: PDFGenerationServiceProtocol {
             throw PDFError.noImages
         }
 
-        let format = UIGraphicsPDFRendererFormat()
-        let renderer = UIGraphicsPDFRenderer(bounds: settings.pageSize.pageRect, format: format)
-
         let tempDir = FileManager.default.temporaryDirectory
         var safeName = outputName.trimmingCharacters(in: .whitespacesAndNewlines)
         if safeName.isEmpty { safeName = "PDF" }
         safeName = safeName.replacingOccurrences(of: "/", with: "_").replacingOccurrences(of: "\\", with: "_")
         let fileURL = tempDir.appendingPathComponent("\(safeName)_\(UUID().uuidString).pdf")
 
-        var failedToCompressPage = false
-        try renderer.writePDF(to: fileURL) { context in
-            for (index, item) in validItems.enumerated() {
-                if failedToCompressPage { break }
-                autoreleasepool {
-                    guard let correctedImage = DocumentImageProcessor.renderedImage(
+        var pages: [LegacyPDFWriter.Page] = []
+        for (index, item) in validItems.enumerated() {
+            try autoreleasepool {
+                guard let correctedImage = DocumentImageProcessor.renderedImage(
                         for: item.0,
                         rotation: item.1,
                         maxPixelDimension: settings.maxPixelDimension
                     ),
-                    let compressedData = correctedImage.jpegData(compressionQuality: settings.jpegQuality),
-                    let embeddedImage = UIImage(data: compressedData) else {
-                        failedToCompressPage = true
-                        return
+                    let jpeg = correctedImage.jpegData(compressionQuality: settings.jpegQuality),
+                    let cgImage = correctedImage.cgImage else {
+                        throw PDFError.compressionFailed
                     }
-
-                    context.beginPage()
                     let pageRect = settings.pageSize.pageRect
-
-                    let imageAspectRatio = embeddedImage.size.width / embeddedImage.size.height
+                    let imageAspectRatio = CGFloat(cgImage.width) / CGFloat(cgImage.height)
                     let pageContentRect = pageRect.insetBy(dx: settings.margin, dy: settings.margin)
                     let pageAspectRatio = pageContentRect.width / pageContentRect.height
 
@@ -93,34 +83,49 @@ final class PDFGenerationService: PDFGenerationServiceProtocol {
                         drawRect = pageContentRect
                     }
 
-                    embeddedImage.draw(in: drawRect)
-
-                    if settings.includePageNumbers {
-                        let pageNumberText = "\(index + 1) / \(validItems.count)"
-                        let font = UIFont.systemFont(ofSize: 10)
-                        let attributes: [NSAttributedString.Key: Any] = [
-                            .font: font,
-                            .foregroundColor: UIColor.black
-                        ]
-
-                        let textSize = pageNumberText.size(withAttributes: attributes)
-                        let textRect = CGRect(
-                            x: pageRect.midX - textSize.width / 2,
-                            y: pageRect.maxY - settings.margin / 2 - textSize.height,
-                            width: textSize.width,
-                            height: textSize.height
-                        )
-                        pageNumberText.draw(in: textRect, withAttributes: attributes)
-                    }
-                }
+                    pages.append(.init(jpeg: jpeg, pixelWidth: cgImage.width, pixelHeight: cgImage.height,
+                                       drawRect: drawRect, pageNumber: settings.includePageNumbers ? "\(index + 1) / \(validItems.count)" : nil))
             }
         }
-        if failedToCompressPage {
-            try? FileManager.default.removeItem(at: fileURL)
-            throw PDFError.compressionFailed
-        }
-
+        try LegacyPDFWriter.write(pages: pages, pageRect: settings.pageSize.pageRect, to: fileURL)
         return fileURL
+    }
+}
+
+private enum LegacyPDFWriter {
+    struct Page { let jpeg: Data; let pixelWidth: Int; let pixelHeight: Int; let drawRect: CGRect; let pageNumber: String? }
+
+    static func write(pages: [Page], pageRect: CGRect, to url: URL) throws {
+        var objects: [Data] = []
+        func ascii(_ value: String) -> Data { Data(value.utf8) }
+        let pageIDs = pages.indices.map { 3 + $0 * 3 }
+        objects.append(ascii("<< /Type /Catalog /Pages 2 0 R >>"))
+        objects.append(ascii("<< /Type /Pages /Count \(pages.count) /Kids [\(pageIDs.map { "\($0) 0 R" }.joined(separator: " "))] /MediaBox [0 0 \(pageRect.width) \(pageRect.height)] >>"))
+
+        for (index, page) in pages.enumerated() {
+            let pageID = pageIDs[index], imageID = pageID + 1, contentID = pageID + 2
+            objects.append(ascii("<< /Type /Page /Parent 2 0 R /Resources << /XObject << /Im0 \(imageID) 0 R >> /Font << /F1 << /Type /Font /Subtype /Type1 /BaseFont /Helvetica >> >> >> /Contents \(contentID) 0 R >>"))
+            var image = ascii("<< /Type /XObject /Subtype /Image /Width \(page.pixelWidth) /Height \(page.pixelHeight) /ColorSpace /DeviceRGB /BitsPerComponent 8 /Filter /DCTDecode /Length \(page.jpeg.count) >>\nstream\n")
+            image.append(page.jpeg); image.append(ascii("\nendstream")); objects.append(image)
+            let r = page.drawRect
+            var commands = "q \(r.width) 0 0 \(r.height) \(r.minX) \(pageRect.height - r.maxY) cm /Im0 Do Q\n"
+            if let number = page.pageNumber {
+                let x = pageRect.midX - CGFloat(number.count) * 2.5
+                commands += "BT /F1 10 Tf \(x) \(max(8, pageRect.height - r.maxY - 18)) Td (\(number)) Tj ET\n"
+            }
+            let content = ascii(commands)
+            var stream = ascii("<< /Length \(content.count) >>\nstream\n"); stream.append(content); stream.append(ascii("endstream")); objects.append(stream)
+        }
+        var result = ascii("%PDF-1.3\n%\u{00E2}\u{00E3}\u{00CF}\u{00D3}\n")
+        var offsets = [0]
+        for (index, object) in objects.enumerated() {
+            offsets.append(result.count); result.append(ascii("\(index + 1) 0 obj\n")); result.append(object); result.append(ascii("\nendobj\n"))
+        }
+        let xref = result.count
+        result.append(ascii("xref\n0 \(objects.count + 1)\n0000000000 65535 f \n"))
+        for offset in offsets.dropFirst() { result.append(ascii(String(format: "%010d 00000 n \n", offset))) }
+        result.append(ascii("trailer\n<< /Size \(objects.count + 1) /Root 1 0 R >>\nstartxref\n\(xref)\n%%EOF\n"))
+        try result.write(to: url, options: .atomic)
     }
 }
 

--- a/LANImageUploader/Services/PDFGenerationService.swift
+++ b/LANImageUploader/Services/PDFGenerationService.swift
@@ -41,7 +41,15 @@ final class PDFGenerationService: PDFGenerationServiceProtocol {
         safeName = safeName.replacingOccurrences(of: "/", with: "_").replacingOccurrences(of: "\\", with: "_")
         let fileURL = tempDir.appendingPathComponent("\(safeName)_\(UUID().uuidString).pdf")
 
-        var pages: [LegacyPDFWriter.Page] = []
+        var writer = try LegacyPDFWriter(pageCount: validItems.count, pageRect: settings.pageSize.pageRect, url: fileURL)
+        var didFinishWriting = false
+        defer {
+            writer.close()
+            if !didFinishWriting {
+                try? FileManager.default.removeItem(at: fileURL)
+            }
+        }
+
         for (index, item) in validItems.enumerated() {
             try autoreleasepool {
                 guard let correctedImage = DocumentImageProcessor.renderedImage(
@@ -83,56 +91,122 @@ final class PDFGenerationService: PDFGenerationServiceProtocol {
                         drawRect = pageContentRect
                     }
 
-                    pages.append(.init(jpeg: jpeg, pixelWidth: cgImage.width, pixelHeight: cgImage.height,
-                                       drawRect: drawRect, pageNumber: settings.includePageNumbers ? "\(index + 1) / \(validItems.count)" : nil))
+                    let page = LegacyPDFWriter.Page(
+                        jpeg: jpeg,
+                        pixelWidth: cgImage.width,
+                        pixelHeight: cgImage.height,
+                        drawRect: drawRect,
+                        pageNumber: settings.includePageNumbers ? "\(index + 1) / \(validItems.count)" : nil,
+                        pageNumberY: max(8, settings.margin / 2)
+                    )
+                    try writer.writePage(page, index: index)
             }
         }
-        try LegacyPDFWriter.write(pages: pages, pageRect: settings.pageSize.pageRect, to: fileURL)
+        try writer.finish()
+        didFinishWriting = true
         return fileURL
     }
 }
 
-private enum LegacyPDFWriter {
-    struct Page { let jpeg: Data; let pixelWidth: Int; let pixelHeight: Int; let drawRect: CGRect; let pageNumber: String? }
+private struct LegacyPDFWriter {
+    struct Page {
+        let jpeg: Data
+        let pixelWidth: Int
+        let pixelHeight: Int
+        let drawRect: CGRect
+        let pageNumber: String?
+        let pageNumberY: CGFloat
+    }
 
-    static func write(pages: [Page], pageRect: CGRect, to url: URL) throws {
-        var objects: [Data] = []
-        func ascii(_ value: String) -> Data { Data(value.utf8) }
-        let pageIDs = pages.indices.map { 3 + $0 * 3 }
-        objects.append(ascii("<< /Type /Catalog /Pages 2 0 R >>"))
-        objects.append(ascii("<< /Type /Pages /Count \(pages.count) /Kids [\(pageIDs.map { "\($0) 0 R" }.joined(separator: " "))] /MediaBox [0 0 \(pageRect.width) \(pageRect.height)] >>"))
+    private let pageCount: Int
+    private let pageRect: CGRect
+    private let handle: FileHandle
+    private var byteOffset = 0
+    private var offsets: [Int] = []
 
-        for (index, page) in pages.enumerated() {
-            let pageID = pageIDs[index], imageID = pageID + 1, contentID = pageID + 2
-            objects.append(ascii("<< /Type /Page /Parent 2 0 R /Resources << /XObject << /Im0 \(imageID) 0 R >> /Font << /F1 << /Type /Font /Subtype /Type1 /BaseFont /Helvetica >> >> >> /Contents \(contentID) 0 R >>"))
-            var image = ascii("<< /Type /XObject /Subtype /Image /Width \(page.pixelWidth) /Height \(page.pixelHeight) /ColorSpace /DeviceRGB /BitsPerComponent 8 /Filter /DCTDecode /Length \(page.jpeg.count) >>\nstream\n")
-            image.append(page.jpeg); image.append(ascii("\nendstream")); objects.append(image)
-            let r = page.drawRect
-            var commands = "q \(r.width) 0 0 \(r.height) \(r.minX) \(pageRect.height - r.maxY) cm /Im0 Do Q\n"
-            if let number = page.pageNumber {
-                let x = pageRect.midX - CGFloat(number.count) * 2.5
-                commands += "BT /F1 10 Tf \(x) \(max(8, pageRect.height - r.maxY - 18)) Td (\(number)) Tj ET\n"
-            }
-            let content = ascii(commands)
-            var stream = ascii("<< /Length \(content.count) >>\nstream\n")
-            stream.append(content)
-            stream.append(ascii("\nendstream"))
-            objects.append(stream)
+    init(pageCount: Int, pageRect: CGRect, url: URL) throws {
+        FileManager.default.createFile(atPath: url.path, contents: nil)
+        self.pageCount = pageCount
+        self.pageRect = pageRect
+        self.handle = try FileHandle(forWritingTo: url)
+
+        writeASCII("%PDF-1.3\n%")
+        writeData(Data([0xE2, 0xE3, 0xCF, 0xD3]))
+        writeASCII("\n")
+
+        let pageIDs = (0..<pageCount).map { Self.pageObjectID(for: $0) }
+        writeObject(id: 1, data: ascii("<< /Type /Catalog /Pages 2 0 R >>"))
+        writeObject(id: 2, data: ascii("<< /Type /Pages /Count \(pageCount) /Kids [\(pageIDs.map { "\($0) 0 R" }.joined(separator: " "))] /MediaBox [0 0 \(pdfNumber(pageRect.width)) \(pdfNumber(pageRect.height))] >>"))
+    }
+
+    mutating func writePage(_ page: Page, index: Int) throws {
+        let pageID = Self.pageObjectID(for: index)
+        let imageID = pageID + 1
+        let contentID = pageID + 2
+        writeObject(id: pageID, data: ascii("<< /Type /Page /Parent 2 0 R /Resources << /XObject << /Im0 \(imageID) 0 R >> /Font << /F1 << /Type /Font /Subtype /Type1 /BaseFont /Helvetica >> >> >> /Contents \(contentID) 0 R >>"))
+
+        writeObjectHeader(id: imageID)
+        writeASCII("<< /Type /XObject /Subtype /Image /Width \(page.pixelWidth) /Height \(page.pixelHeight) /ColorSpace /DeviceRGB /BitsPerComponent 8 /Filter /DCTDecode /Length \(page.jpeg.count) >>\nstream\n")
+        writeData(page.jpeg)
+        writeASCII("\nendstream\nendobj\n")
+
+        let r = page.drawRect
+        var commands = "q \(pdfNumber(r.width)) 0 0 \(pdfNumber(r.height)) \(pdfNumber(r.minX)) \(pdfNumber(pageRect.height - r.maxY)) cm /Im0 Do Q\n"
+        if let number = page.pageNumber {
+            let x = pageRect.midX - CGFloat(number.count) * 2.5
+            commands += "BT /F1 10 Tf \(pdfNumber(x)) \(pdfNumber(page.pageNumberY)) Td (\(number)) Tj ET\n"
         }
-        var result = ascii("%PDF-1.3\n%")
-        result.append(contentsOf: [0xE2, 0xE3, 0xCF, 0xD3])
-        result.append(ascii("\n"))
-        var offsets = [0]
-        for (index, object) in objects.enumerated() {
-            offsets.append(result.count); result.append(ascii("\(index + 1) 0 obj\n")); result.append(object); result.append(ascii("\nendobj\n"))
+        let content = ascii(commands)
+        var stream = ascii("<< /Length \(content.count) >>\nstream\n")
+        stream.append(content)
+        stream.append(ascii("\nendstream"))
+        writeObject(id: contentID, data: stream)
+    }
+
+    mutating func finish() throws {
+        let xref = byteOffset
+        writeASCII("xref\n0 \(offsets.count + 1)\n0000000000 65535 f \n")
+        for offset in offsets {
+            writeASCII(String(format: "%010d 00000 n \n", locale: Locale(identifier: "en_US_POSIX"), offset))
         }
-        let xref = result.count
-        result.append(ascii("xref\n0 \(objects.count + 1)\n0000000000 65535 f \n"))
-        for offset in offsets.dropFirst() {
-            result.append(ascii(String(format: "%010d 00000 n \n", locale: Locale(identifier: "en_US_POSIX"), offset)))
-        }
-        result.append(ascii("trailer\n<< /Size \(objects.count + 1) /Root 1 0 R >>\nstartxref\n\(xref)\n%%EOF\n"))
-        try result.write(to: url, options: .atomic)
+        writeASCII("trailer\n<< /Size \(offsets.count + 1) /Root 1 0 R >>\nstartxref\n\(xref)\n%%EOF\n")
+        try handle.close()
+    }
+
+    func close() {
+        try? handle.close()
+    }
+
+    private static func pageObjectID(for index: Int) -> Int {
+        3 + index * 3
+    }
+
+    private mutating func writeObject(id: Int, data: Data) {
+        writeObjectHeader(id: id)
+        writeData(data)
+        writeASCII("\nendobj\n")
+    }
+
+    private mutating func writeObjectHeader(id: Int) {
+        offsets.append(byteOffset)
+        writeASCII("\(id) 0 obj\n")
+    }
+
+    private mutating func writeASCII(_ value: String) {
+        writeData(ascii(value))
+    }
+
+    private mutating func writeData(_ data: Data) {
+        handle.write(data)
+        byteOffset += data.count
+    }
+
+    private func ascii(_ value: String) -> Data {
+        Data(value.utf8)
+    }
+
+    private func pdfNumber(_ value: CGFloat) -> String {
+        String(format: "%.3f", locale: Locale(identifier: "en_US_POSIX"), Double(value))
     }
 }
 

--- a/LANImageUploaderTests/GalleryModelsTests.swift
+++ b/LANImageUploaderTests/GalleryModelsTests.swift
@@ -9,6 +9,14 @@ import UIKit
 @testable import LANImageUploader
 
 struct GalleryModelsTests {
+    @Test func scanCameraGalleryRouteUsesSinglePDFOutput() {
+        #expect(CameraGalleryRoute(captureMode: .scan).outputMode == .singlePDF)
+    }
+
+    @Test func photoCameraGalleryRouteUsesSeparateImagesOutput() {
+        #expect(CameraGalleryRoute(captureMode: .photo).outputMode == .separateImages)
+    }
+
 
     @Test func testImageRotationNextClockwise() {
         #expect(ImageRotation.degrees0.nextClockwise == .degrees90)

--- a/LANImageUploaderTests/LANImageUploaderTests.swift
+++ b/LANImageUploaderTests/LANImageUploaderTests.swift
@@ -856,6 +856,28 @@ struct LANImageUploaderTests {
         #expect(xrefSection.contains(" 00000 n "))
     }
 
+    @Test func generatedPDFAnchorsPageNumbersToFooter() async throws {
+        let source = Self.makeCompressionTestImage(size: CGSize(width: 1200, height: 700))
+        let sourceURL = FileManager.default.temporaryDirectory.appendingPathComponent("\(UUID()).jpg")
+        try #require(source.jpegData(compressionQuality: 1)).write(to: sourceURL)
+        let item = GalleryItem(
+            id: UUID(),
+            capturedImage: CapturedImage(name: "landscape", fileURL: sourceURL, crop: .fullFrame, isDocumentScan: true),
+            rotation: .degrees0
+        )
+        defer { try? FileManager.default.removeItem(at: sourceURL) }
+
+        let pdf = try await PDFGenerationService.shared.generatePDF(
+            from: [item],
+            outputName: "footer",
+            settings: PDFSettings(includePageNumbers: true)
+        )
+        defer { try? FileManager.default.removeItem(at: pdf) }
+
+        let text = try #require(String(data: Data(contentsOf: pdf), encoding: .isoLatin1))
+        #expect(text.contains("12.000 Td (1 / 1) Tj ET"))
+    }
+
     @Test @MainActor func deleteAllRetainedImagesClearsGalleryAndRemovesFiles() async {
         let mockFile = MockFileService()
         let appData = AppData(

--- a/LANImageUploaderTests/LANImageUploaderTests.swift
+++ b/LANImageUploaderTests/LANImageUploaderTests.swift
@@ -841,9 +841,22 @@ struct LANImageUploaderTests {
         defer { try? FileManager.default.removeItem(at: pdf) }
 
         let contents = try Data(contentsOf: pdf)
+        #expect(contents.starts(with: Data([0x25, 0x50, 0x44, 0x46, 0x2D, 0x31, 0x2E, 0x33, 0x0A, 0x25, 0xE2, 0xE3, 0xCF, 0xD3, 0x0A])))
         #expect(contents.range(of: Data("/Filter /DCTDecode".utf8)) != nil)
         #expect(contents.range(of: Data("/ColorSpace /DeviceRGB".utf8)) != nil)
         #expect(contents.range(of: Data("/ICCBased".utf8)) == nil)
+        #expect(contents.range(of: Data("\nendstream".utf8)) != nil)
+
+        let text = try #require(String(data: contents, encoding: .isoLatin1))
+        let xrefStart = try #require(text.range(of: "\nxref\n")?.upperBound)
+        let xrefRemainder = text[xrefStart...]
+        let xrefEnd = try #require(xrefRemainder.range(of: "\ntrailer\n")?.lowerBound)
+        let xrefSection = xrefRemainder[..<xrefEnd]
+        let xrefLines = xrefSection.components(separatedBy: "\n").filter { $0.hasSuffix(" 00000 n ") }
+        #expect(!xrefLines.isEmpty)
+        #expect(xrefLines.allSatisfy { line in
+            line.count == 20 && line.prefix(10).allSatisfy(\.isASCII) && line.prefix(10).allSatisfy(\.isNumber)
+        })
     }
 
     @Test @MainActor func deleteAllRetainedImagesClearsGalleryAndRemovesFiles() async {

--- a/LANImageUploaderTests/LANImageUploaderTests.swift
+++ b/LANImageUploaderTests/LANImageUploaderTests.swift
@@ -852,11 +852,8 @@ struct LANImageUploaderTests {
         let xrefRemainder = text[xrefStart...]
         let xrefEnd = try #require(xrefRemainder.range(of: "\ntrailer\n")?.lowerBound)
         let xrefSection = xrefRemainder[..<xrefEnd]
-        let xrefLines = xrefSection.components(separatedBy: "\n").filter { $0.hasSuffix(" 00000 n ") }
-        #expect(!xrefLines.isEmpty)
-        #expect(xrefLines.allSatisfy { line in
-            line.count == 20 && line.prefix(10).allSatisfy(\.isASCII) && line.prefix(10).allSatisfy(\.isNumber)
-        })
+        #expect(xrefSection.utf8.allSatisfy { $0 < 128 })
+        #expect(xrefSection.contains(" 00000 n "))
     }
 
     @Test @MainActor func deleteAllRetainedImagesClearsGalleryAndRemovesFiles() async {

--- a/LANImageUploaderTests/LANImageUploaderTests.swift
+++ b/LANImageUploaderTests/LANImageUploaderTests.swift
@@ -822,6 +822,30 @@ struct LANImageUploaderTests {
         #expect(try Data(contentsOf: lowQuality).count < Data(contentsOf: highQuality).count)
     }
 
+    @Test func generatedPDFUsesLegacyCompatibleJPEGColorSpace() async throws {
+        let source = Self.makeCompressionTestImage(size: CGSize(width: 800, height: 1100))
+        let sourceURL = FileManager.default.temporaryDirectory.appendingPathComponent("\(UUID()).jpg")
+        try #require(source.jpegData(compressionQuality: 1)).write(to: sourceURL)
+        let item = GalleryItem(
+            id: UUID(),
+            capturedImage: CapturedImage(name: "scan", fileURL: sourceURL, crop: .fullFrame, isDocumentScan: true),
+            rotation: .degrees0
+        )
+        defer { try? FileManager.default.removeItem(at: sourceURL) }
+
+        let pdf = try await PDFGenerationService.shared.generatePDF(
+            from: [item],
+            outputName: "compatible",
+            settings: PDFSettings(includePageNumbers: false)
+        )
+        defer { try? FileManager.default.removeItem(at: pdf) }
+
+        let contents = try Data(contentsOf: pdf)
+        #expect(contents.range(of: Data("/Filter /DCTDecode".utf8)) != nil)
+        #expect(contents.range(of: Data("/ColorSpace /DeviceRGB".utf8)) != nil)
+        #expect(contents.range(of: Data("/ICCBased".utf8)) == nil)
+    }
+
     @Test @MainActor func deleteAllRetainedImagesClearsGalleryAndRemovesFiles() async {
         let mockFile = MockFileService()
         let appData = AppData(


### PR DESCRIPTION
## What changed
- replace UIGraphicsPDFRenderer output with a conservative PDF 1.3 writer
- embed scanned pages as JPEG/DCTDecode using DeviceRGB
- preserve page sizing, image layout, compression, and optional page numbers
- add a regression test asserting the legacy-compatible PDF structure

## Why
EG Clinea's Media Library displays PDFs generated with ICCBased, Flate-compressed image objects as blank pages, although modern viewers render them correctly. The new output avoids that unsupported color-space/image combination.

## Validation
- git diff --check
- regression test added for DCTDecode, DeviceRGB, and absence of ICCBased
- iOS build/tests not run because this checkout is on Windows; run the Xcode test suite on macOS before merging