### PR TITLE
Reduce scanner memory and align captured framing

### DIFF
--- a/LANImageUploader/AppData.swift
+++ b/LANImageUploader/AppData.swift
@@ -135,6 +135,10 @@ struct UploadFailureDetail: Equatable {
 }
 
 class AppData: ObservableObject {
+    private struct SendableImage: @unchecked Sendable {
+        let value: UIImage
+    }
+
     @Published var images: [CapturedImage] = [] {
         didSet { saveImageQueue() }
     }
@@ -214,17 +218,43 @@ class AppData: ObservableObject {
         _ image: UIImage,
         crop: DocumentCrop? = nil,
         isDocumentScan: Bool? = nil,
-        capturedAt date: Date = Date()
+        capturedAt date: Date = Date(),
+        id: UUID = UUID()
+    ) async throws -> CapturedImage {
+        let sendableImage = SendableImage(value: image)
+        let data = try await Task.detached(priority: .userInitiated) {
+            try autoreleasepool {
+                guard let data = sendableImage.value.jpegData(compressionQuality: 0.8) else {
+                    throw CocoaError(.fileWriteUnknown)
+                }
+                return data
+            }
+        }.value
+
+        return try await saveCapturedImageData(
+            data,
+            crop: crop,
+            isDocumentScan: isDocumentScan,
+            capturedAt: date,
+            id: id
+        )
+    }
+
+    @discardableResult
+    func saveCapturedImageData(
+        _ data: Data,
+        crop: DocumentCrop? = nil,
+        isDocumentScan: Bool? = nil,
+        capturedAt date: Date = Date(),
+        id: UUID = UUID()
     ) async throws -> CapturedImage {
         let timestamp = CapturedImageTimestampFormatter.shared.string(from: date)
-        let fileName = "IMG_\(timestamp).jpg"
-
-        guard let data = image.jpegData(compressionQuality: 0.8) else {
-            throw CocoaError(.fileWriteUnknown)
-        }
+        let uniqueSuffix = id.uuidString.prefix(8).lowercased()
+        let fileName = "IMG_\(timestamp)_\(uniqueSuffix).jpg"
 
         let fileURL = try await fileService.saveImage(data, fileName: fileName)
         let captured = CapturedImage(
+            id: id,
             name: fileName.removingSuffix(".jpg"),
             fileURL: fileURL,
             crop: crop,

--- a/LANImageUploader/CameraPicker.swift
+++ b/LANImageUploader/CameraPicker.swift
@@ -119,6 +119,7 @@ struct CameraZoomOption: Identifiable, Equatable {
     }
 
     static let standard = CameraZoomOption(factor: 1, displayFactor: 1)
+    static let preferredDisplayFactors: [CGFloat] = [0.5, 1, 2, 3, 4]
 }
 
 struct PhotoCaptureFraming {
@@ -152,6 +153,21 @@ struct PhotoCaptureFraming {
         ).integral.intersection(CGRect(origin: .zero, size: size))
         guard !crop.isEmpty, let framed = cgImage.cropping(to: crop) else { return upright }
         return UIImage(cgImage: framed, scale: upright.scale, orientation: .up)
+    }
+
+    static func visibleCrop(imageSize: CGSize, previewSize: CGSize) -> DocumentCrop {
+        let rect = normalizedVisibleRect(imageSize: imageSize, previewSize: previewSize)
+        return DocumentCrop(
+            topLeft: CGPoint(x: rect.minX, y: rect.minY),
+            topRight: CGPoint(x: rect.maxX, y: rect.minY),
+            bottomRight: CGPoint(x: rect.maxX, y: rect.maxY),
+            bottomLeft: CGPoint(x: rect.minX, y: rect.maxY)
+        )
+    }
+
+    static func crop(_ crop: DocumentCrop, isVisibleIn visibleRect: CGRect, epsilon: CGFloat = 0.002) -> Bool {
+        let expanded = visibleRect.insetBy(dx: -epsilon, dy: -epsilon)
+        return crop.points.allSatisfy(expanded.contains)
     }
 
     static func normalizedOrientationImage(_ image: UIImage) -> UIImage {
@@ -252,7 +268,7 @@ struct DocumentPreviewGeometry {
 struct ScannerCaptureView: View {
     let keptPhotoCount: Int
     let scannedPageCount: Int
-    let onScanCapture: (UIImage, DocumentCrop?) -> Void
+    let onScanCapture: (Data, DocumentCrop?, @escaping () -> Void) -> Void
     let onKeepPhoto: (UIImage) -> Void
     let onCountdownTick: () -> Void
     let onOpenGallery: (CameraCaptureMode) -> Void
@@ -272,7 +288,7 @@ struct ScannerCaptureView: View {
         initialMode: CameraCaptureMode,
         keptPhotoCount: Int,
         scannedPageCount: Int,
-        onScanCapture: @escaping (UIImage, DocumentCrop?) -> Void,
+        onScanCapture: @escaping (Data, DocumentCrop?, @escaping () -> Void) -> Void,
         onKeepPhoto: @escaping (UIImage) -> Void,
         onCountdownTick: @escaping () -> Void,
         onOpenGallery: @escaping (CameraCaptureMode) -> Void,
@@ -686,7 +702,7 @@ struct DocumentCameraPreview: UIViewControllerRepresentable {
     @Binding var autoCapture: Bool
     let captureRequest: UUID
     let selectedZoomFactor: CGFloat
-    let onScanCapture: (UIImage, DocumentCrop?) -> Void
+    let onScanCapture: (Data, DocumentCrop?, @escaping () -> Void) -> Void
     let onPhotoCapture: (UIImage) -> Void
     let onDetectionChanged: (String, Bool) -> Void
     let onCountdownChanged: (Int?) -> Void
@@ -761,7 +777,7 @@ final class DocumentCameraViewController: UIViewController, AVCapturePhotoCaptur
             onDetectionChanged?(newValue == .scan ? "Point the camera at a document" : "", false)
         }
     }
-    var onScanCapture: ((UIImage, DocumentCrop?) -> Void)?
+    var onScanCapture: ((Data, DocumentCrop?, @escaping () -> Void) -> Void)?
     var onPhotoCapture: ((UIImage) -> Void)?
     var onDetectionChanged: ((String, Bool) -> Void)?
     var onCountdownChanged: ((Int?) -> Void)?
@@ -976,12 +992,19 @@ final class DocumentCameraViewController: UIViewController, AVCapturePhotoCaptur
     }
 
     func capturePage(autoTriggered: Bool = false) {
-        guard session.isRunning, !captureInProgress else { return }
+        guard !captureInProgress else { return }
         captureInProgress = true
         pendingCaptureMode = mode
         let currentGeneration = orientationLock.withLock { orientationGeneration }
         pendingCaptureDetection = mode == .scan
-            ? latestDetection.flatMap { $0.orientationGeneration == currentGeneration ? $0 : nil }
+            ? latestDetection.flatMap { detection in
+                guard detection.orientationGeneration == currentGeneration else { return nil }
+                return DetectedCrop(
+                    crop: displayedCrop ?? detection.crop,
+                    orientedBufferSize: detection.orientedBufferSize,
+                    orientationGeneration: detection.orientationGeneration
+                )
+            }
             : nil
         pendingPhotoPreviewSize = previewLayer.bounds.size
         if autoTriggered, mode == .scan {
@@ -990,7 +1013,15 @@ final class DocumentCameraViewController: UIViewController, AVCapturePhotoCaptur
         }
         let settings = AVCapturePhotoSettings()
         settings.flashMode = photoOutput.supportedFlashModes.contains(.auto) ? .auto : .off
-        photoOutput.capturePhoto(with: settings, delegate: self)
+        sessionQueue.async { [weak self] in
+            guard let self, self.session.isRunning else {
+                DispatchQueue.main.async { self?.captureInProgress = false }
+                return
+            }
+            // The session queue also applies zoom changes, so queuing capture here
+            // guarantees that the saved photo uses the zoom shown as selected.
+            self.photoOutput.capturePhoto(with: settings, delegate: self)
+        }
     }
 
     func photoOutput(
@@ -998,40 +1029,64 @@ final class DocumentCameraViewController: UIViewController, AVCapturePhotoCaptur
         didFinishProcessingPhoto photo: AVCapturePhoto,
         error: Error?
     ) {
-        let image = error == nil
-            ? photo.fileDataRepresentation().flatMap(UIImage.init(data:))
-            : nil
+        let data = error == nil ? photo.fileDataRepresentation() : nil
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
-            self.captureInProgress = false
-            guard let image else { return }
+            guard let data else {
+                self.captureInProgress = false
+                return
+            }
             let captureMode = self.pendingCaptureMode
             let detection = self.pendingCaptureDetection
             let previewSize = self.pendingPhotoPreviewSize
             self.photoProcessingQueue.async { [weak self] in
                 guard let self else { return }
                 if captureMode == .scan {
-                    let upright = PhotoCaptureFraming.normalizedOrientationImage(image)
-                    let photoSize = upright.cgImage.map {
-                        CGSize(width: $0.width, height: $0.height)
-                    } ?? upright.size
-                    let crop = detection?
+                    guard let photoSize = CIImage(
+                        data: data,
+                        options: [.applyOrientationProperty: true]
+                    )?.extent.size else {
+                        DispatchQueue.main.async { self.captureInProgress = false }
+                        return
+                    }
+                    let visibleRect = PhotoCaptureFraming.normalizedVisibleRect(
+                        imageSize: photoSize,
+                        previewSize: previewSize
+                    )
+                    let detectedCrop = detection?
                         .crop
                         .mapped(
                             fromAspectFillImageSize: detection?.orientedBufferSize ?? .zero,
                             toImageSize: photoSize
                         )
                         .flatMap { $0.isValidForPerspectiveCorrection() ? $0.clamped() : nil }
+                    let crop = detectedCrop.flatMap {
+                        PhotoCaptureFraming.crop($0, isVisibleIn: visibleRect) ? $0 : nil
+                    } ?? PhotoCaptureFraming.visibleCrop(
+                        imageSize: photoSize,
+                        previewSize: previewSize
+                    )
                     DispatchQueue.main.async {
-                        self.onScanCapture?(upright, crop)
+                        guard let onScanCapture = self.onScanCapture else {
+                            self.captureInProgress = false
+                            return
+                        }
+                        onScanCapture(data, crop) { [weak self] in
+                            self?.captureInProgress = false
+                        }
                     }
                 } else {
+                    guard let image = UIImage(data: data) else {
+                        DispatchQueue.main.async { self.captureInProgress = false }
+                        return
+                    }
                     let framed = PhotoCaptureFraming.image(
                         image,
                         matchingAspectFillPreview: previewSize
                     )
                     DispatchQueue.main.async {
                         self.onPhotoCapture?(framed)
+                        self.captureInProgress = false
                     }
                 }
             }
@@ -1291,10 +1346,9 @@ final class DocumentCameraViewController: UIViewController, AVCapturePhotoCaptur
 
     private func zoomOptions(for device: AVCaptureDevice) -> [CameraZoomOption] {
         let multiplier = device.displayVideoZoomFactorMultiplier
-        let desiredDisplayFactors: [CGFloat] = [0.5, 1, 2, 3]
         var factors = [device.minAvailableVideoZoomFactor, 1]
         factors.append(contentsOf: device.virtualDeviceSwitchOverVideoZoomFactors.map { CGFloat($0.doubleValue) })
-        factors.append(contentsOf: desiredDisplayFactors.map { $0 / multiplier })
+        factors.append(contentsOf: CameraZoomOption.preferredDisplayFactors.map { $0 / multiplier })
         let available = factors.filter {
             $0 >= device.minAvailableVideoZoomFactor && $0 <= device.maxAvailableVideoZoomFactor
         }.sorted()

--- a/LANImageUploader/CameraView.swift
+++ b/LANImageUploader/CameraView.swift
@@ -31,9 +31,12 @@ struct CameraView: View {
             initialMode: initialMode,
             keptPhotoCount: keptCount,
             scannedPageCount: scannedCount,
-            onScanCapture: { image, crop in
+            onScanCapture: { data, crop, captureFinished in
                 Task {
-                    await saveImage(image: image, crop: crop, isDocumentScan: true)
+                    await saveImageData(data, crop: crop, isDocumentScan: true)
+                    await MainActor.run {
+                        captureFinished()
+                    }
                 }
             },
             onKeepPhoto: { image in
@@ -77,6 +80,28 @@ struct CameraView: View {
         do {
             try await appData.saveCapturedImage(
                 image,
+                crop: crop,
+                isDocumentScan: isDocumentScan
+            )
+            await MainActor.run {
+                appData.hapticService.playNotification(type: .success)
+            }
+        } catch {
+            await MainActor.run {
+                showError = true
+                errorMessage = "Failed to save image: \(error.localizedDescription)"
+            }
+        }
+    }
+
+    func saveImageData(
+        _ data: Data,
+        crop: DocumentCrop? = nil,
+        isDocumentScan: Bool = false
+    ) async {
+        do {
+            try await appData.saveCapturedImageData(
+                data,
                 crop: crop,
                 isDocumentScan: isDocumentScan
             )

--- a/LANImageUploader/GalleryItemView.swift
+++ b/LANImageUploader/GalleryItemView.swift
@@ -70,6 +70,9 @@ struct GalleryItemView: View {
             .task(id: imageReloadID) {
                 await loadImage()
             }
+            .onDisappear {
+                uiImage = nil
+            }
 
             // Index badge
             Text("\(index + 1)")
@@ -133,18 +136,12 @@ struct GalleryItemView: View {
 
     @ViewBuilder
     private func thumbnailImage(_ image: UIImage, isDocumentScan: Bool) -> some View {
-        if isDocumentScan {
-            ZStack {
-                RoundedRectangle(cornerRadius: 12)
-                    .fill(Color.black.opacity(0.16))
-                Image(uiImage: image)
-                    .resizable()
-                    .scaledToFit()
-            }
-        } else {
+        ZStack {
+            RoundedRectangle(cornerRadius: 12)
+                .fill(Color.black.opacity(isDocumentScan ? 0.16 : 0.08))
             Image(uiImage: image)
                 .resizable()
-                .scaledToFill()
+                .scaledToFit()
         }
     }
 
@@ -162,7 +159,13 @@ struct GalleryItemView: View {
         }
 
         let image: UIImage? = await Task.detached(priority: .userInitiated) { () -> UIImage? in
-            DocumentImageProcessor.renderedImage(for: capturedImage, rotation: item.rotation)
+            autoreleasepool {
+                DocumentImageProcessor.renderedImage(
+                    for: capturedImage,
+                    rotation: item.rotation,
+                    maxPixelDimension: 640
+                )
+            }
         }.value
 
         await MainActor.run {

--- a/LANImageUploader/GalleryView.swift
+++ b/LANImageUploader/GalleryView.swift
@@ -23,7 +23,7 @@ private enum GalleryNamingIntent {
     case batchRenameAndUpload
 }
 
-private struct GalleryExportRequest {
+private struct GalleryExportRequest: Sendable {
     let order: Int
     let image: CapturedImage
     let name: String
@@ -591,35 +591,31 @@ struct GalleryView: View {
         maxPixelDimension: CGFloat,
         jpegQuality: CGFloat
     ) async throws -> [UploadableFile] {
-        try await withThrowingTaskGroup(of: (Int, UploadableFile).self) { group in
-            for request in requests {
-                group.addTask {
-                    let file = try autoreleasepool {
-                        let exportURL = try DocumentImageProcessor.exportJPEG(
-                            for: request.image,
-                            rotation: request.image.rotation,
-                            name: request.name,
-                            maxPixelDimension: maxPixelDimension,
-                            jpegQuality: jpegQuality
-                        )
-                        return UploadableFile(
-                            id: request.image.id,
-                            name: request.name,
-                            fileURL: exportURL,
-                            kind: .jpeg,
-                            sourceImageIDs: [request.image.id]
-                        )
-                    }
-                    return (request.order, file)
+        var files: [(Int, UploadableFile)] = []
+        files.reserveCapacity(requests.count)
+        for request in requests {
+            try Task.checkCancellation()
+            let file = try await Task.detached(priority: .userInitiated) {
+                try autoreleasepool {
+                    let exportURL = try DocumentImageProcessor.exportJPEG(
+                        for: request.image,
+                        rotation: request.image.rotation,
+                        name: request.name,
+                        maxPixelDimension: maxPixelDimension,
+                        jpegQuality: jpegQuality
+                    )
+                    return UploadableFile(
+                        id: request.image.id,
+                        name: request.name,
+                        fileURL: exportURL,
+                        kind: .jpeg,
+                        sourceImageIDs: [request.image.id]
+                    )
                 }
-            }
-
-            var files: [(Int, UploadableFile)] = []
-            for try await file in group {
-                files.append(file)
-            }
-            return files.sorted { $0.0 < $1.0 }.map(\.1)
+            }.value
+            files.append((request.order, file))
         }
+        return files.sorted { $0.0 < $1.0 }.map(\.1)
     }
 
     @MainActor

--- a/LANImageUploader/ImageUploadService.swift
+++ b/LANImageUploader/ImageUploadService.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 import AMSMB2
-import UIKit
 
 /// Service responsible for uploading images to an SMB share.
 final class ImageUploadService: ImageUploadServiceProtocol {
@@ -93,15 +92,7 @@ final class ImageUploadService: ImageUploadServiceProtocol {
         let fileData: Data
 
         switch file.kind {
-        case .jpeg:
-            guard let originalImage = UIImage(contentsOfFile: file.fileURL.path) else {
-                throw UploadError.fileUnreadable
-            }
-            guard let data = originalImage.jpegData(compressionQuality: 1.0) else {
-                throw UploadError.dataPreparationFailed
-            }
-            fileData = data
-        case .pdf:
+        case .jpeg, .pdf:
             do {
                 fileData = try Data(contentsOf: file.fileURL)
             } catch {

--- a/LANImageUploaderTests/GalleryModelsTests.swift
+++ b/LANImageUploaderTests/GalleryModelsTests.swift
@@ -17,6 +17,24 @@ struct GalleryModelsTests {
         #expect(CameraGalleryRoute(captureMode: .photo).outputMode == .separateImages)
     }
 
+    @Test func cameraOffersAllSupportedUserFacingZoomTargets() {
+        #expect(CameraZoomOption.preferredDisplayFactors == [0.5, 1, 2, 3, 4])
+    }
+
+    @Test func visibleCropMatchesAspectFillPreviewFraming() {
+        let crop = PhotoCaptureFraming.visibleCrop(
+            imageSize: CGSize(width: 400, height: 300),
+            previewSize: CGSize(width: 300, height: 300)
+        )
+
+        #expect(abs(crop.topLeft.x - 0.125) < 0.001)
+        #expect(abs(crop.topRight.x - 0.875) < 0.001)
+        #expect(crop.topLeft.y == 0)
+        #expect(crop.bottomRight.y == 1)
+        #expect(PhotoCaptureFraming.crop(.fullFrame, isVisibleIn: CGRect(x: 0, y: 0, width: 1, height: 1)))
+        #expect(!PhotoCaptureFraming.crop(.fullFrame, isVisibleIn: CGRect(x: 0.125, y: 0, width: 0.75, height: 1)))
+    }
+
 
     @Test func testImageRotationNextClockwise() {
         #expect(ImageRotation.degrees0.nextClockwise == .degrees90)

--- a/LANImageUploaderTests/LANImageUploaderTests.swift
+++ b/LANImageUploaderTests/LANImageUploaderTests.swift
@@ -308,12 +308,47 @@ struct LANImageUploaderTests {
         components.second = 12
         let date = try #require(components.date)
 
-        let captured = try await appData.saveCapturedImage(image, capturedAt: date)
+        let captureID = UUID(uuidString: "12345678-1234-1234-1234-123456789abc")!
+        let captured = try await appData.saveCapturedImage(image, capturedAt: date, id: captureID)
 
         #expect(mockFile.savedImages.count == 1)
-        #expect(mockFile.savedImages.first?.fileName == "IMG_20260515_101112.jpg")
-        #expect(captured.name == "IMG_20260515_101112")
-        #expect(appData.images.map { $0.name } == ["IMG_20260515_101112"])
+        #expect(mockFile.savedImages.first?.fileName == "IMG_20260515_101112_12345678.jpg")
+        #expect(captured.name == "IMG_20260515_101112_12345678")
+        #expect(appData.images.map { $0.name } == ["IMG_20260515_101112_12345678"])
+    }
+
+    @Test @MainActor func scannerDataSavePreservesCompressedBytesAndUsesUniqueNames() async throws {
+        let mockFile = MockFileService()
+        let appData = AppData(
+            fileService: mockFile,
+            uploadService: MockImageUploadService(),
+            discoveryService: MockNetworkDiscovery(),
+            hapticService: MockHapticFeedbackService()
+        )
+        let data = Data([0xff, 0xd8, 0xff, 0xd9])
+        let date = Date(timeIntervalSince1970: 1_700_000_000)
+        let firstID = UUID(uuidString: "aaaaaaaa-1234-1234-1234-123456789abc")!
+        let secondID = UUID(uuidString: "bbbbbbbb-1234-1234-1234-123456789abc")!
+
+        _ = try await appData.saveCapturedImageData(
+            data,
+            crop: .fullFrame,
+            isDocumentScan: true,
+            capturedAt: date,
+            id: firstID
+        )
+        _ = try await appData.saveCapturedImageData(
+            data,
+            crop: .fullFrame,
+            isDocumentScan: true,
+            capturedAt: date,
+            id: secondID
+        )
+
+        #expect(mockFile.savedImages.map(\.data) == [data, data])
+        #expect(mockFile.savedImages[0].fileName != mockFile.savedImages[1].fileName)
+        #expect(mockFile.savedImages[0].fileName.hasSuffix("_aaaaaaaa.jpg"))
+        #expect(mockFile.savedImages[1].fileName.hasSuffix("_bbbbbbbb.jpg"))
     }
 
     @Test func capturedImageTimestampFormatterIsDeterministicAndThreadSafe() async throws {


### PR DESCRIPTION
## Summary

- persist scanned pages from compressed capture data and serialize scan saves
- bound Gallery and batch-export memory use, and upload prepared JPEG bytes directly
- align scan/photo framing, thumbnails, zoom selection, and exported output
- prevent same-second captures from overwriting one another

## Root cause

Full-resolution pages could be decoded and rendered concurrently across capture, Gallery, export, and upload. Scan fallback framing and Gallery photo thumbnails also differed from what the user saw in the live viewfinder.

## Validation

- Xcode simulator build succeeded
- full test suite: 52 passed, 0 failed, 3 skipped
- structured simulator gate succeeded with 0 errors
- scanner open/close memgraph reported 0 leaks