### PR TITLE
Fix SMB validation and promo unlock refresh

### DIFF
--- a/LANImageUploader/LANImageUploaderApp.swift
+++ b/LANImageUploader/LANImageUploaderApp.swift
@@ -23,6 +23,7 @@ class ClearBackgroundHostingController<Content: View>: UIHostingController<Conte
 struct LANImageUploaderApp: App {
     @AppStorage(Constants.UserDefaults.onboardingCompleted) var onboardingCompleted: Bool = false
     @StateObject private var appData: AppData
+    @StateObject private var purchaseManager = StoreKitPurchaseManager()
     @Environment(\.scenePhase) private var scenePhase
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
@@ -128,10 +129,15 @@ struct LANImageUploaderApp: App {
             }
             .task {
                 await appData.premiumAccess.refreshPremiumOverrideEligibility()
+                await purchaseManager.syncPurchasedEntitlements(accessController: appData.premiumAccess)
+                purchaseManager.startObservingTransactionUpdates(accessController: appData.premiumAccess)
             }
             .onChange(of: scenePhase) { _, newPhase in
                 if newPhase == .active {
                     scheduleDailyImageSave()
+                    Task {
+                        await purchaseManager.syncPurchasedEntitlements(accessController: appData.premiumAccess)
+                    }
                 }
             }
         }

--- a/LANImageUploader/NetworkDiscovery.swift
+++ b/LANImageUploader/NetworkDiscovery.swift
@@ -88,16 +88,15 @@ extension NetworkDiscovery {
         onStatus: (@Sendable (ConnectionStatus) -> Void)? = nil
     ) async throws -> NetworkInfo {
         let normalizedIP = serverIP.trimmingCharacters(in: .whitespacesAndNewlines)
-        let normalizedShare = shareName.trimmingCharacters(in: .whitespacesAndNewlines)
-        let normalizedDirectory = targetDirectory?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .trimmingCharacters(in: CharacterSet(charactersIn: "/\\\\"))
+        guard let target = SMBConnectionTarget(
+            shareName: shareName,
+            targetDirectory: targetDirectory ?? ""
+        ) else {
+            throw ConnectionError.folderNotFound("Share name is required.")
+        }
 
         guard !normalizedIP.isEmpty else {
             throw ConnectionError.hostNotFound("Server address is required.")
-        }
-        guard !normalizedShare.isEmpty else {
-            throw ConnectionError.folderNotFound("Share name is required.")
         }
         if try await !networkMonitor.waitForNetwork(timeout: 3.0) {
             let error = ConnectionError.networkUnavailable
@@ -105,42 +104,18 @@ extension NetworkDiscovery {
             throw error
         }
 
-        var components = URLComponents()
-        components.scheme = "smb"
-        components.host = normalizedIP
-        components.port = port
-        guard let serverURL = components.url,
-              let client = SMB2Manager(
-                url: serverURL,
-                credential: URLCredential(user: username, password: password, persistence: .forSession)
-              ) else {
-            let error = ConnectionError.hostNotFound(normalizedIP)
-            onStatus?(.failure(error))
-            throw error
-        }
-
-        do {
-            onStatus?(.connecting(normalizedIP))
-            onStatus?(.authenticating)
-            try await client.connectShare(name: normalizedShare)
-            if let normalizedDirectory, !normalizedDirectory.isEmpty {
-                try await ensureDirectoryExists(normalizedDirectory, in: client, shareName: normalizedShare)
-            }
-            try await client.disconnectShare()
-
-            let info = NetworkInfo(
-                serverIP: normalizedIP,
-                shareName: normalizedShare,
-                targetDirectory: normalizedDirectory?.isEmpty == true ? nil : normalizedDirectory
-            )
-            onStatus?(.connected(info))
-            return info
-        } catch {
-            try? await client.disconnectShare()
-            let mappedError = mapToConnectionError(error)
-            onStatus?(.failure(mappedError))
-            throw mappedError
-        }
+        // Use the mature validation path that setup has used since before the
+        // direct Test Connection button existed. It authenticates via IPC$ and
+        // resolves legacy share/directory layouts before reporting an auth
+        // failure, instead of treating a share-path mismatch as bad credentials.
+        return try await attemptConnection(
+            ipAddress: normalizedIP,
+            targetFolder: target.validationTargetFolder,
+            username: username,
+            password: password,
+            port: port,
+            onStatus: onStatus
+        )
     }
 
     internal func retrieveNetworkInfo(

--- a/LANImageUploader/SettingsView.swift
+++ b/LANImageUploader/SettingsView.swift
@@ -11,6 +11,16 @@ struct SMBConnectionTarget: Equatable {
     let shareName: String
     let targetDirectory: String?
 
+    /// The legacy SMB validator accepts one share-relative target path. Keeping
+    /// this conversion here lets the direct connection test use the same
+    /// resolution path as the established setup flow.
+    var validationTargetFolder: String {
+        guard let targetDirectory, !targetDirectory.isEmpty else {
+            return shareName
+        }
+        return "\(shareName)/\(targetDirectory)"
+    }
+
     init?(shareName: String, targetDirectory: String) {
         let normalizedShare = shareName.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !normalizedShare.isEmpty else { return nil }

--- a/LANImageUploader/StoreKitPurchaseManager.swift
+++ b/LANImageUploader/StoreKitPurchaseManager.swift
@@ -44,11 +44,18 @@ final class StoreKitPurchaseManager: ObservableObject {
     @Published private(set) var restorationStatus: PurchaseRestorationStatus?
 
     private let restorePurchasesAction: @MainActor () async throws -> Bool
+    private let entitlementRefreshAction: @MainActor () async -> Bool
+    private let transactionUpdatesAction: @MainActor () -> AsyncStream<Void>
+    private var transactionUpdatesTask: Task<Void, Never>?
 
     init(
-        restorePurchasesAction: @escaping @MainActor () async throws -> Bool = StoreKitPurchaseManager.restoreFullUnlockEntitlement
+        restorePurchasesAction: @escaping @MainActor () async throws -> Bool = StoreKitPurchaseManager.restoreFullUnlockEntitlement,
+        entitlementRefreshAction: @escaping @MainActor () async -> Bool = StoreKitPurchaseManager.hasFullUnlockEntitlement,
+        transactionUpdatesAction: @escaping @MainActor () -> AsyncStream<Void> = StoreKitPurchaseManager.fullUnlockTransactionUpdates
     ) {
         self.restorePurchasesAction = restorePurchasesAction
+        self.entitlementRefreshAction = entitlementRefreshAction
+        self.transactionUpdatesAction = transactionUpdatesAction
     }
 
     func loadFullUnlockProduct() async {
@@ -99,12 +106,21 @@ final class StoreKitPurchaseManager: ObservableObject {
     }
 
     func syncPurchasedEntitlements(accessController: PremiumAccessController) async {
-        for await result in Transaction.currentEntitlements {
-            guard let transaction = try? Self.checkVerified(result),
-                  transaction.productID == PremiumAccessConstants.fullUnlockProductID else {
-                continue
-            }
+        if await entitlementRefreshAction() {
             accessController.markPurchasedFullUnlock()
+        }
+    }
+
+    /// Listens for purchases and promo codes redeemed outside the purchase view.
+    func startObservingTransactionUpdates(accessController: PremiumAccessController) {
+        guard transactionUpdatesTask == nil else { return }
+
+        let transactionUpdates = transactionUpdatesAction()
+        transactionUpdatesTask = Task { [weak accessController] in
+            for await _ in transactionUpdates {
+                guard let accessController else { break }
+                accessController.markPurchasedFullUnlock()
+            }
         }
     }
 
@@ -131,6 +147,10 @@ final class StoreKitPurchaseManager: ObservableObject {
     private static func restoreFullUnlockEntitlement() async throws -> Bool {
         try await AppStore.sync()
 
+        return await hasFullUnlockEntitlement()
+    }
+
+    private static func hasFullUnlockEntitlement() async -> Bool {
         for await result in Transaction.currentEntitlements {
             guard let transaction = try? checkVerified(result),
                   transaction.productID == PremiumAccessConstants.fullUnlockProductID else {
@@ -140,6 +160,27 @@ final class StoreKitPurchaseManager: ObservableObject {
         }
 
         return false
+    }
+
+    private static func fullUnlockTransactionUpdates() -> AsyncStream<Void> {
+        AsyncStream { continuation in
+            let task = Task {
+                for await result in Transaction.updates {
+                    guard let transaction = try? checkVerified(result),
+                          transaction.productID == PremiumAccessConstants.fullUnlockProductID else {
+                        continue
+                    }
+
+                    await transaction.finish()
+                    continuation.yield()
+                }
+                continuation.finish()
+            }
+
+            continuation.onTermination = { _ in
+                task.cancel()
+            }
+        }
     }
 
     private static func checkVerified<T>(_ result: VerificationResult<T>) throws -> T {

--- a/LANImageUploaderTests/LANImageUploaderTests.swift
+++ b/LANImageUploaderTests/LANImageUploaderTests.swift
@@ -720,6 +720,17 @@ struct LANImageUploaderTests {
         #expect(sharePrefixedDirectory.targetDirectory == "Data/MediaCapture")
     }
 
+    @Test func smbConnectionTargetBuildsLegacyValidationTargetFromShareAndDirectory() throws {
+        let target = try #require(
+            SMBConnectionTarget(
+                shareName: "MediaCaptureShare",
+                targetDirectory: "Data/MediaCapture"
+            )
+        )
+
+        #expect(target.validationTargetFolder == "MediaCaptureShare/Data/MediaCapture")
+    }
+
     @Test func connectionErrorMappingExists() async throws {
         let authError = ConnectionError.authenticationFailed
         #expect(authError.localizedDescription.contains("password"))
@@ -935,6 +946,59 @@ struct LANImageUploaderTests {
         #expect(access.state.isFullAppUnlocked)
         #expect(purchaseManager.restorationStatus == .restored)
         #expect(!purchaseManager.isRestoring)
+    }
+
+    @Test @MainActor func promoCodeEntitlementRefreshRemovesUploadLimit() async {
+        let store = InMemoryPremiumAccessStore()
+        store.successfulUploadCount = PremiumAccessConstants.trialUploadLimit
+        let access = PremiumAccessController(store: store)
+        let purchaseManager = StoreKitPurchaseManager(
+            restorePurchasesAction: { false },
+            entitlementRefreshAction: { true }
+        )
+
+        await purchaseManager.syncPurchasedEntitlements(accessController: access)
+
+        #expect(access.state.isFullAppUnlocked)
+        #expect(access.state.canUpload)
+        #expect(!access.state.shouldShowTrialStatus)
+    }
+
+    @Test @MainActor func promoCodeTransactionUpdateRemovesUploadLimitWithoutOpeningPurchaseView() async {
+        let store = InMemoryPremiumAccessStore()
+        store.successfulUploadCount = PremiumAccessConstants.trialUploadLimit
+        let access = PremiumAccessController(store: store)
+        var continuation: AsyncStream<Void>.Continuation?
+        let updates = AsyncStream<Void> { continuation = $0 }
+        let purchaseManager = StoreKitPurchaseManager(
+            restorePurchasesAction: { false },
+            entitlementRefreshAction: { false },
+            transactionUpdatesAction: { updates }
+        )
+
+        purchaseManager.startObservingTransactionUpdates(accessController: access)
+        continuation?.yield()
+        for _ in 0..<100 where !access.state.isFullAppUnlocked {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+
+        #expect(access.state.isFullAppUnlocked)
+        #expect(access.state.canUpload)
+        continuation?.finish()
+    }
+
+    @Test @MainActor func failedEntitlementRefreshPreservesExistingFullUnlock() async {
+        let store = InMemoryPremiumAccessStore()
+        store.hasPurchasedFullUnlock = true
+        let access = PremiumAccessController(store: store)
+        let purchaseManager = StoreKitPurchaseManager(
+            restorePurchasesAction: { false },
+            entitlementRefreshAction: { false }
+        )
+
+        await purchaseManager.syncPurchasedEntitlements(accessController: access)
+
+        #expect(access.state.isFullAppUnlocked)
     }
 
     @Test @MainActor func restorePurchasesReportsWhenNoEntitlementIsFound() async {


### PR DESCRIPTION
## What changed

- Route Settings connection validation through the established SMB share and directory resolution path.
- Refresh verified Full App Unlock entitlements at app launch and when the app returns active.
- Observe verified StoreKit transaction updates so App Store promo-code redemptions unlock Premium without opening the purchase screen.
- Add focused regression coverage for SMB target reconstruction and promo entitlement handling.

## Root causes

The newer Test Connection implementation bypassed the mature IPC$/share candidate validation path, causing share or directory failures to be reported as invalid credentials. Promo redemptions were only synchronized from the Full Unlock screen, so out-of-band StoreKit entitlements did not update the upload-limit state.

## User impact

Valid SMB credentials are validated using the same proven path as setup/discovery, and verified promo-code entitlements now remove the free upload limit during normal app lifecycle events.

## Validation

- Full `LANImageUploaderTests` suite: 75/75 passed on iPhone 17 Pro Simulator, iOS 26.5.
- Targeted out-of-band Promo Code transaction test passed.
- Swift parse and `git diff --check` passed.
- Built app installed and launched; Settings opened through semantic Simulator navigation.

Live SMB authentication and real App Store promo redemption remain physical/environment verification gates.