### PR TITLE
Bump LensBridge to 1.60 for TestFlight

### DIFF
--- a/LANImageUploader.xcodeproj/project.pbxproj
+++ b/LANImageUploader.xcodeproj/project.pbxproj
@@ -673,7 +673,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.59;
+				MARKETING_VERSION = 1.60;
 				PRODUCT_BUNDLE_IDENTIFIER = com.janhagenclausen.LANImageUploader;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -713,7 +713,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.59;
+				MARKETING_VERSION = 1.60;
 				PRODUCT_BUNDLE_IDENTIFIER = com.janhagenclausen.LANImageUploader;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
## Summary
- bump both LensBridge app-target marketing versions from 1.59 to 1.60
- keep build number at 65: Xcode Cloud run-number override controls upload sequencing

## Verification
- resolved Release settings: 1.60 (65), unchanged bundle identifier
- iPhone 17 Pro simulator Release tests passed with 0 errors and 0 warnings

No signing, bundle identifier, entitlement, or unrelated-worktree changes.