### PR TITLE
Fix Full Unlock entitlement restore fallback

### DIFF
--- a/LANImageUploader/StoreKitPurchaseManager.swift
+++ b/LANImageUploader/StoreKitPurchaseManager.swift
@@ -18,7 +18,7 @@ enum PurchaseRestorationStatus: Equatable {
         case .restored:
             return "Full App Unlock has been restored."
         case .noRestorablePurchase:
-            return "No previous Full App Unlock purchase was found for this Apple Account."
+            return "No Full App Unlock purchase was found for this Apple Account. An App Store code that only downloads LensBridge does not include the separate Full App Unlock in-app purchase."
         case .failed(let message):
             return "Unable to restore purchases: \(message)"
         }
@@ -131,6 +131,15 @@ final class StoreKitPurchaseManager: ObservableObject {
         restorationStatus = nil
         defer { isRestoring = false }
 
+        // Check the verified StoreKit 2 entitlement first. A valid non-consumable
+        // is already sufficient to restore access, even if AppStore.sync cannot
+        // complete on this device or account.
+        if await entitlementRefreshAction() {
+            accessController.markPurchasedFullUnlock()
+            restorationStatus = .restored
+            return
+        }
+
         do {
             guard try await restorePurchasesAction() else {
                 restorationStatus = .noRestorablePurchase
@@ -140,12 +149,23 @@ final class StoreKitPurchaseManager: ObservableObject {
             accessController.markPurchasedFullUnlock()
             restorationStatus = .restored
         } catch {
-            restorationStatus = .failed(error.localizedDescription)
+            // AppStore.sync is best-effort. It can fail after StoreKit has
+            // refreshed a verified entitlement, so give currentEntitlements one
+            // final chance before surfacing a restore error.
+            if await entitlementRefreshAction() {
+                accessController.markPurchasedFullUnlock()
+                restorationStatus = .restored
+            } else {
+                restorationStatus = .failed(error.localizedDescription)
+            }
         }
     }
 
     private static func restoreFullUnlockEntitlement() async throws -> Bool {
-        try await AppStore.sync()
+        // AppStore.sync may fail for a transient App Store account request. The
+        // verified entitlement remains the source of truth, so still inspect it
+        // and report the honest no-entitlement state instead of a generic error.
+        try? await AppStore.sync()
 
         return await hasFullUnlockEntitlement()
     }

--- a/LANImageUploaderTests/LANImageUploaderTests.swift
+++ b/LANImageUploaderTests/LANImageUploaderTests.swift
@@ -1028,6 +1028,28 @@ struct LANImageUploaderTests {
         #expect(!purchaseManager.isRestoring)
     }
 
+    @Test @MainActor func restorePurchasesUsesVerifiedEntitlementWhenStoreSyncFails() async {
+        let store = InMemoryPremiumAccessStore()
+        let access = PremiumAccessController(store: store)
+        var entitlementCheckCount = 0
+        let purchaseManager = StoreKitPurchaseManager(
+            restorePurchasesAction: {
+                throw CocoaError(.fileReadUnknown)
+            },
+            entitlementRefreshAction: {
+                entitlementCheckCount += 1
+                return entitlementCheckCount == 2
+            }
+        )
+
+        await purchaseManager.restorePurchases(accessController: access)
+
+        #expect(entitlementCheckCount == 2)
+        #expect(access.state.isFullAppUnlocked)
+        #expect(purchaseManager.restorationStatus == .restored)
+        #expect(!purchaseManager.isRestoring)
+    }
+
     @Test @MainActor func restorePurchasesIgnoresRepeatedRequestsWhileRestoring() async {
         let store = InMemoryPremiumAccessStore()
         let access = PremiumAccessController(store: store)
@@ -1036,7 +1058,7 @@ struct LANImageUploaderTests {
             restoreInvocationCount += 1
             try await Task.sleep(for: .milliseconds(100))
             return true
-        })
+        }, entitlementRefreshAction: { false })
 
         let firstRestore = Task { @MainActor in
             await purchaseManager.restorePurchases(accessController: access)


### PR DESCRIPTION
## Summary
- restore a verified Full App Unlock entitlement even when `AppStore.sync()` fails
- check StoreKit entitlements before sync and once more after a sync error
- explain that an app-download promo code does not include the separate Full App Unlock in-app purchase
- add a regression test reproducing the sync-error/verified-entitlement path

## Root cause
The approved `Full App Unlock` non-consumable has no IAP offer codes. App promo codes download LensBridge; they do not create a `com.janhagenclausen.LANImageUploader.fullunlock` transaction. Separately, restore treated `AppStore.sync()` failure as fatal and skipped a verified entitlement fallback.

## Verification
- regression test failed before the implementation and passes after it
- `LANImageUploaderTests`: 76 passed, 0 failed, 0 skipped
- simulator build and launch succeeded on iPhone 17 Pro (iOS 26.5)
- `git diff --check` passed