### PR TITLE
Add TestFlight-only Full App Unlock toggle

### DIFF
--- a/LANImageUploader/LANImageUploaderApp.swift
+++ b/LANImageUploader/LANImageUploaderApp.swift
@@ -136,6 +136,7 @@ struct LANImageUploaderApp: App {
                 if newPhase == .active {
                     scheduleDailyImageSave()
                     Task {
+                        await appData.premiumAccess.refreshPremiumOverrideEligibility()
                         await purchaseManager.syncPurchasedEntitlements(accessController: appData.premiumAccess)
                     }
                 }

--- a/LANImageUploader/PremiumAccess.swift
+++ b/LANImageUploader/PremiumAccess.swift
@@ -103,8 +103,12 @@ final class PremiumAccessController: ObservableObject {
         )
     }
 
-    func refreshPremiumOverrideEligibility() async {
-        let isAllowed = await AppDistribution.resolvePremiumOverrideEligibility()
+    func refreshPremiumOverrideEligibility(
+        environmentProvider: @escaping AppDistribution.AppTransactionEnvironmentProvider = AppDistribution.currentAppTransactionEnvironment
+    ) async {
+        let isAllowed = await AppDistribution.resolvePremiumOverrideEligibility(
+            environmentProvider: environmentProvider
+        )
         await MainActor.run {
             self.premiumOverrideAllowed = isAllowed
             self.reload()
@@ -113,23 +117,45 @@ final class PremiumAccessController: ObservableObject {
 }
 
 enum AppDistribution {
-    // TESTFLIGHT_BUILD is supplied explicitly when creating a TestFlight
-    // candidate. App Store archives omit it, so the validation control and its
-    // implementation are not compiled into the submitted production binary.
+    typealias AppTransactionEnvironmentProvider = () async throws -> AppStore.Environment
+
+    // Eligibility is resolved asynchronously from StoreKit at launch. Keep the
+    // synchronous default fail-closed until AppTransaction.shared has been
+    // verified, so a production build can never expose the validation control
+    // merely because of a stale flag or build setting.
     static func allowsPremiumOverride() -> Bool {
-        #if DEBUG || TESTFLIGHT_BUILD
-        return true
-        #else
         return false
-        #endif
     }
 
-    static func resolvePremiumOverrideEligibility() async -> Bool {
-        #if DEBUG || TESTFLIGHT_BUILD
-        return true
-        #else
-        return false
-        #endif
+    static func resolvePremiumOverrideEligibility(
+        environmentProvider: @escaping AppTransactionEnvironmentProvider = currentAppTransactionEnvironment
+    ) async -> Bool {
+        do {
+            let environment = try await environmentProvider()
+            // TestFlight transactions are signed by StoreKit's sandbox
+            // environment. A production App Store transaction is deliberately
+            // excluded, even when the app was previously installed through
+            // TestFlight on the same device.
+            return environment == .sandbox
+        } catch {
+            // An unavailable or unverified app transaction is not evidence that
+            // the app came from TestFlight. Fail closed in that case.
+            return false
+        }
+    }
+
+    static func currentAppTransactionEnvironment() async throws -> AppStore.Environment {
+        let verification = try await AppTransaction.shared
+        switch verification {
+        case .verified(let transaction):
+            return transaction.environment
+        case .unverified:
+            throw AppDistributionError.unverifiedAppTransaction
+        }
+    }
+
+    private enum AppDistributionError: Error {
+        case unverifiedAppTransaction
     }
 }
 

--- a/LANImageUploader/SettingsView.swift
+++ b/LANImageUploader/SettingsView.swift
@@ -432,17 +432,15 @@ struct SettingsView: View {
 
     var premiumSection: some View {
         Section("Premium") {
-            #if DEBUG || TESTFLIGHT_BUILD
             if appData.premiumAccess.state.canUsePremiumOverride {
-                Toggle("Premium override", isOn: Binding(
+                Toggle("Full App Unlock", isOn: Binding(
                     get: { appData.premiumAccess.state.isPremiumOverrideEnabled },
                     set: { appData.premiumAccess.setPremiumOverrideEnabled($0) }
                 ))
-                Text("Bypasses the paywall for TestFlight validation only.")
+                Text("Unlocks all uploads for TestFlight validation only.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
-            #endif
 
             if appData.premiumAccess.state.isFullAppUnlocked {
                 Label("Full App Unlock active", systemImage: "checkmark.seal.fill")

--- a/LANImageUploaderTests/LANImageUploaderTests.swift
+++ b/LANImageUploaderTests/LANImageUploaderTests.swift
@@ -923,6 +923,66 @@ struct LANImageUploaderTests {
         #expect(!access.state.canUpload)
     }
 
+    @Test func premiumOverrideIsAllowedForSandboxTestFlightEnvironment() async {
+        let isAllowed = await AppDistribution.resolvePremiumOverrideEligibility {
+            .sandbox
+        }
+
+        #expect(isAllowed)
+    }
+
+    @Test func premiumOverrideIsHiddenForProductionAppStoreEnvironment() async {
+        let isAllowed = await AppDistribution.resolvePremiumOverrideEligibility {
+            .production
+        }
+
+        #expect(!isAllowed)
+    }
+
+    @Test func premiumOverrideFailsClosedForUnverifiedAppTransaction() async {
+        let isAllowed = await AppDistribution.resolvePremiumOverrideEligibility {
+            throw TestAppTransactionError.unverified
+        }
+
+        #expect(!isAllowed)
+    }
+
+    @Test func premiumOverrideFailsClosedWhenAppTransactionLookupFails() async {
+        let isAllowed = await AppDistribution.resolvePremiumOverrideEligibility {
+            throw TestAppTransactionError.requestFailed
+        }
+
+        #expect(!isAllowed)
+    }
+
+    @Test @MainActor func premiumOverrideEligibilityRefreshEnablesSandboxTestFlightToggle() async {
+        let store = InMemoryPremiumAccessStore()
+        store.successfulUploadCount = 15
+        let access = PremiumAccessController(store: store, canUsePremiumOverride: { false })
+
+        #expect(!access.state.canUsePremiumOverride)
+        await access.refreshPremiumOverrideEligibility { .sandbox }
+
+        #expect(access.state.canUsePremiumOverride)
+        access.setPremiumOverrideEnabled(true)
+        #expect(access.state.isFullAppUnlocked)
+    }
+
+    @Test @MainActor func premiumOverrideEligibilityRefreshHidesProductionToggleAndClearsOverride() async {
+        let store = InMemoryPremiumAccessStore()
+        store.successfulUploadCount = 15
+        let access = PremiumAccessController(store: store, canUsePremiumOverride: { true })
+        access.setPremiumOverrideEnabled(true)
+        #expect(access.state.isFullAppUnlocked)
+
+        await access.refreshPremiumOverrideEligibility { .production }
+
+        #expect(!access.state.canUsePremiumOverride)
+        #expect(!access.state.isPremiumOverrideEnabled)
+        #expect(!access.state.isFullAppUnlocked)
+        #expect(!store.isPremiumOverrideEnabled)
+    }
+
     @Test @MainActor func purchasedUnlockPersistsWhenDeveloperModeIsOff() async throws {
         let store = InMemoryPremiumAccessStore()
         store.successfulUploadCount = 15
@@ -1485,6 +1545,11 @@ struct LANImageUploaderTests {
         )
         return (CGFloat(pixel[0]) + CGFloat(pixel[1]) + CGFloat(pixel[2])) / (3 * 255)
     }
+}
+
+private enum TestAppTransactionError: Error {
+    case unverified
+    case requestFailed
 }
 
 private final class InMemoryPremiumAccessStore: PremiumAccessPersisting {


### PR DESCRIPTION
## Summary
- detect TestFlight at runtime from a verified StoreKit `AppTransaction` sandbox environment
- show a `Full App Unlock` toggle in Settings only for TestFlight builds
- fail closed for App Store production, unverified transactions, and StoreKit failures
- refresh eligibility on launch and foreground, clearing stale overrides in production

## Verification
- LANImageUploaderTests: 82 passed, 0 failed
- Release iOS Simulator build succeeded
- `git diff --check` passed

## Safety
- no signing, bundle identifier, entitlement, or project-file changes
- production App Store installs cannot expose the toggle without a verified sandbox app transaction