### PR TITLE
Make TestFlight premium toggle deterministic

### DIFF
--- a/LANImageUploader/LANImageUploaderApp.swift
+++ b/LANImageUploader/LANImageUploaderApp.swift
@@ -128,7 +128,7 @@ struct LANImageUploaderApp: App {
                 }
             }
             .task {
-                await appData.premiumAccess.refreshPremiumOverrideEligibility()
+                appData.premiumAccess.refreshPremiumOverrideEligibility()
                 await purchaseManager.syncPurchasedEntitlements(accessController: appData.premiumAccess)
                 purchaseManager.startObservingTransactionUpdates(accessController: appData.premiumAccess)
             }
@@ -136,7 +136,7 @@ struct LANImageUploaderApp: App {
                 if newPhase == .active {
                     scheduleDailyImageSave()
                     Task {
-                        await appData.premiumAccess.refreshPremiumOverrideEligibility()
+                        appData.premiumAccess.refreshPremiumOverrideEligibility()
                         await purchaseManager.syncPurchasedEntitlements(accessController: appData.premiumAccess)
                     }
                 }

--- a/LANImageUploader/PremiumAccess.swift
+++ b/LANImageUploader/PremiumAccess.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 import Security
-import StoreKit
 
 struct PremiumAccessState: Equatable {
     let isFullAppUnlocked: Bool
@@ -104,58 +103,46 @@ final class PremiumAccessController: ObservableObject {
     }
 
     func refreshPremiumOverrideEligibility(
-        environmentProvider: @escaping AppDistribution.AppTransactionEnvironmentProvider = AppDistribution.currentAppTransactionEnvironment
-    ) async {
-        let isAllowed = await AppDistribution.resolvePremiumOverrideEligibility(
-            environmentProvider: environmentProvider
-        )
-        await MainActor.run {
-            self.premiumOverrideAllowed = isAllowed
-            self.reload()
-        }
+        canUsePremiumOverride: () -> Bool = AppDistribution.allowsPremiumOverride
+    ) {
+        premiumOverrideAllowed = canUsePremiumOverride()
+        reload()
     }
 }
 
+enum AppBuildChannel: String, Equatable {
+    case production
+    case testFlight
+}
+
+enum BuildDistributionChannel {
+    // Xcode Cloud's ci_pre_xcodebuild.sh rewrites this before every action.
+    // Checked-in source remains production, so a missing or mismatched workflow
+    // cannot expose the validation control.
+    static let current: AppBuildChannel = .production
+}
+
 enum AppDistribution {
-    typealias AppTransactionEnvironmentProvider = () async throws -> AppStore.Environment
-
-    // Eligibility is resolved asynchronously from StoreKit at launch. Keep the
-    // synchronous default fail-closed until AppTransaction.shared has been
-    // verified, so a production build can never expose the validation control
-    // merely because of a stale flag or build setting.
     static func allowsPremiumOverride() -> Bool {
-        return false
+        allowsPremiumOverride(
+            buildChannel: BuildDistributionChannel.current,
+            isDebugBuild: isDebugBuild
+        )
     }
 
-    static func resolvePremiumOverrideEligibility(
-        environmentProvider: @escaping AppTransactionEnvironmentProvider = currentAppTransactionEnvironment
-    ) async -> Bool {
-        do {
-            let environment = try await environmentProvider()
-            // TestFlight transactions are signed by StoreKit's sandbox
-            // environment. A production App Store transaction is deliberately
-            // excluded, even when the app was previously installed through
-            // TestFlight on the same device.
-            return environment == .sandbox
-        } catch {
-            // An unavailable or unverified app transaction is not evidence that
-            // the app came from TestFlight. Fail closed in that case.
-            return false
-        }
+    static func allowsPremiumOverride(
+        buildChannel: AppBuildChannel,
+        isDebugBuild: Bool
+    ) -> Bool {
+        isDebugBuild || buildChannel == .testFlight
     }
 
-    static func currentAppTransactionEnvironment() async throws -> AppStore.Environment {
-        let verification = try await AppTransaction.shared
-        switch verification {
-        case .verified(let transaction):
-            return transaction.environment
-        case .unverified:
-            throw AppDistributionError.unverifiedAppTransaction
-        }
-    }
-
-    private enum AppDistributionError: Error {
-        case unverifiedAppTransaction
+    private static var isDebugBuild: Bool {
+        #if DEBUG
+        true
+        #else
+        false
+        #endif
     }
 }
 

--- a/LANImageUploaderTests/LANImageUploaderTests.swift
+++ b/LANImageUploaderTests/LANImageUploaderTests.swift
@@ -923,59 +923,41 @@ struct LANImageUploaderTests {
         #expect(!access.state.canUpload)
     }
 
-    @Test func premiumOverrideIsAllowedForSandboxTestFlightEnvironment() async {
-        let isAllowed = await AppDistribution.resolvePremiumOverrideEligibility {
-            .sandbox
-        }
-
-        #expect(isAllowed)
+    @Test func premiumOverrideIsHiddenForProductionBuildChannel() {
+        #expect(
+            !AppDistribution.allowsPremiumOverride(
+                buildChannel: .production,
+                isDebugBuild: false
+            )
+        )
     }
 
-    @Test func premiumOverrideIsHiddenForProductionAppStoreEnvironment() async {
-        let isAllowed = await AppDistribution.resolvePremiumOverrideEligibility {
-            .production
-        }
-
-        #expect(!isAllowed)
+    @Test func premiumOverrideIsAllowedForExactTestFlightBuildChannel() {
+        #expect(
+            AppDistribution.allowsPremiumOverride(
+                buildChannel: .testFlight,
+                isDebugBuild: false
+            )
+        )
     }
 
-    @Test func premiumOverrideFailsClosedForUnverifiedAppTransaction() async {
-        let isAllowed = await AppDistribution.resolvePremiumOverrideEligibility {
-            throw TestAppTransactionError.unverified
-        }
-
-        #expect(!isAllowed)
+    @Test func premiumOverrideFailsClosedForMismatchedTestFlightWorkflow() {
+        #expect(
+            !AppDistribution.allowsPremiumOverride(
+                buildChannel: .production,
+                isDebugBuild: false
+            )
+        )
     }
 
-    @Test func premiumOverrideFailsClosedWhenAppTransactionLookupFails() async {
-        let isAllowed = await AppDistribution.resolvePremiumOverrideEligibility {
-            throw TestAppTransactionError.requestFailed
-        }
-
-        #expect(!isAllowed)
-    }
-
-    @Test @MainActor func premiumOverrideEligibilityRefreshEnablesSandboxTestFlightToggle() async {
-        let store = InMemoryPremiumAccessStore()
-        store.successfulUploadCount = 15
-        let access = PremiumAccessController(store: store, canUsePremiumOverride: { false })
-
-        #expect(!access.state.canUsePremiumOverride)
-        await access.refreshPremiumOverrideEligibility { .sandbox }
-
-        #expect(access.state.canUsePremiumOverride)
-        access.setPremiumOverrideEnabled(true)
-        #expect(access.state.isFullAppUnlocked)
-    }
-
-    @Test @MainActor func premiumOverrideEligibilityRefreshHidesProductionToggleAndClearsOverride() async {
+    @Test @MainActor func premiumOverrideEligibilityRefreshClearsPersistedOverrideWhenIneligible() {
         let store = InMemoryPremiumAccessStore()
         store.successfulUploadCount = 15
         let access = PremiumAccessController(store: store, canUsePremiumOverride: { true })
         access.setPremiumOverrideEnabled(true)
         #expect(access.state.isFullAppUnlocked)
 
-        await access.refreshPremiumOverrideEligibility { .production }
+        access.refreshPremiumOverrideEligibility { false }
 
         #expect(!access.state.canUsePremiumOverride)
         #expect(!access.state.isPremiumOverrideEnabled)
@@ -1545,11 +1527,6 @@ struct LANImageUploaderTests {
         )
         return (CGFloat(pixel[0]) + CGFloat(pixel[1]) + CGFloat(pixel[2])) / (3 * 255)
     }
-}
-
-private enum TestAppTransactionError: Error {
-    case unverified
-    case requestFailed
 }
 
 private final class InMemoryPremiumAccessStore: PremiumAccessPersisting {

--- a/ci_scripts/ci_pre_xcodebuild.sh
+++ b/ci_scripts/ci_pre_xcodebuild.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source_file="${BUILD_CHANNEL_SOURCE_FILE:-$repo_root/LANImageUploader/PremiumAccess.swift}"
+expected_workflow_id="37c9d62c-448d-4f60-8672-496a5c044c34"
+expected_workflow_name="TestFlight - external beta test"
+
+if [[ ! -f "$source_file" ]]; then
+    printf 'Build distribution channel source is missing.\n' >&2
+    exit 1
+fi
+
+# Reset the channel for every Cloud action. Only the one locked external-beta
+# workflow can repopulate it, so missing or mismatched CI metadata fails closed
+# to production.
+channel_source='.production'
+if [[ "${CI_WORKFLOW_ID:-}" == "$expected_workflow_id" \
+    && "${CI_WORKFLOW:-}" == "$expected_workflow_name" ]]; then
+    channel_source='.testFlight'
+fi
+
+/usr/bin/sed -i '' -E \
+    "s#static let current: AppBuildChannel = \\.(production|testFlight)#static let current: AppBuildChannel = $channel_source#" \
+    "$source_file"

--- a/ci_scripts/ci_pre_xcodebuild.sh
+++ b/ci_scripts/ci_pre_xcodebuild.sh
@@ -4,11 +4,18 @@ set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source_file="${BUILD_CHANNEL_SOURCE_FILE:-$repo_root/LANImageUploader/PremiumAccess.swift}"
+info_plist="${BUILD_CHANNEL_INFO_PLIST:-$repo_root/LANImageUploader/Info.plist}"
 expected_workflow_id="37c9d62c-448d-4f60-8672-496a5c044c34"
 expected_workflow_name="TestFlight - external beta test"
+marker_key='LensBridgeBuildChannelMarker'
+testflight_marker='external-testflight-v1'
 
 if [[ ! -f "$source_file" ]]; then
     printf 'Build distribution channel source is missing.\n' >&2
+    exit 1
+fi
+if [[ ! -f "$info_plist" ]]; then
+    printf 'Build distribution channel Info.plist is missing.\n' >&2
     exit 1
 fi
 
@@ -47,5 +54,21 @@ rewritten_count="$(/usr/bin/awk -v expected="static let current: AppBuildChannel
 ' "$source_file")"
 if [[ "$rewritten_count" != "1" ]]; then
     printf 'Build distribution channel rewrite verification failed.\n' >&2
+    exit 1
+fi
+
+/usr/libexec/PlistBuddy -c "Delete :$marker_key" "$info_plist" >/dev/null 2>&1 || true
+if [[ "$channel_source" == '.testFlight' ]]; then
+    /usr/libexec/PlistBuddy -c "Add :$marker_key string $testflight_marker" "$info_plist"
+fi
+
+if [[ "$channel_source" == '.testFlight' ]]; then
+    marker_value="$(/usr/libexec/PlistBuddy -c "Print :$marker_key" "$info_plist" 2>/dev/null || true)"
+    if [[ "$marker_value" != "$testflight_marker" ]]; then
+        printf 'TestFlight build-channel marker verification failed.\n' >&2
+        exit 1
+    fi
+elif /usr/libexec/PlistBuddy -c "Print :$marker_key" "$info_plist" >/dev/null 2>&1; then
+    printf 'Production build-channel marker removal failed.\n' >&2
     exit 1
 fi

--- a/ci_scripts/ci_pre_xcodebuild.sh
+++ b/ci_scripts/ci_pre_xcodebuild.sh
@@ -12,6 +12,17 @@ if [[ ! -f "$source_file" ]]; then
     exit 1
 fi
 
+declaration_count="$(/usr/bin/awk '
+    /^[[:space:]]*static let current: AppBuildChannel = \.(production|testFlight)[[:space:]]*$/ {
+        count += 1
+    }
+    END { print count + 0 }
+' "$source_file")"
+if [[ "$declaration_count" != "1" ]]; then
+    printf 'Build distribution channel declaration must appear exactly once.\n' >&2
+    exit 1
+fi
+
 # Reset the channel for every Cloud action. Only the one locked external-beta
 # workflow can repopulate it, so missing or mismatched CI metadata fails closed
 # to production.
@@ -24,3 +35,17 @@ fi
 /usr/bin/sed -i '' -E \
     "s#static let current: AppBuildChannel = \\.(production|testFlight)#static let current: AppBuildChannel = $channel_source#" \
     "$source_file"
+
+rewritten_count="$(/usr/bin/awk -v expected="static let current: AppBuildChannel = $channel_source" '
+    function trim(value) {
+        sub(/^[[:space:]]+/, "", value)
+        sub(/[[:space:]]+$/, "", value)
+        return value
+    }
+    trim($0) == expected { count += 1 }
+    END { print count + 0 }
+' "$source_file")"
+if [[ "$rewritten_count" != "1" ]]; then
+    printf 'Build distribution channel rewrite verification failed.\n' >&2
+    exit 1
+fi

--- a/docs/APP-STORE-RELEASE-PLAN.md
+++ b/docs/APP-STORE-RELEASE-PLAN.md
@@ -252,10 +252,10 @@ plan: a green compile or unit-test run is not enough to call the app release-rea
   not retain one full `Data` buffer per concurrent upload. Gallery JPEG/PDF
   preparation is cancellable and cleans generated temporary files; local
   deletion only commits metadata/UI removal after the file operation succeeds.
-  The TestFlight-only premium override is gated by the explicit
-  `TESTFLIGHT_BUILD` Swift compilation condition. TestFlight Release archives
-  set that condition; App Store archives omit it, so the toggle and its
-  implementation are absent from the submitted production binary. Gallery PDF
+  The TestFlight-only premium override is gated by the deterministic build
+  channel written by `ci_scripts/ci_pre_xcodebuild.sh`. The exact external-beta
+  workflow writes `.testFlight`; all other Cloud actions write `.production`.
+  Gallery PDF
   generation now has explicit cancellation propagation from the SwiftUI task to
   the detached page renderer, with partial-output cleanup retained in the PDF
   service.
@@ -270,11 +270,13 @@ plan: a green compile or unit-test run is not enough to call the app release-rea
   with 0 failures and 0 skips out of 88 discovered, with no reported warnings
   or errors. The result bundle is recorded in the scanner test matrix.
 - Reproducible build gates:
-  - App Store archive: omit `SWIFT_ACTIVE_COMPILATION_CONDITIONS=TESTFLIGHT_BUILD`.
-  - TestFlight archive: add
-    `SWIFT_ACTIVE_COMPILATION_CONDITIONS=TESTFLIGHT_BUILD`.
-  - Verify the production IPA with `strings` and require `Premium override` to
-    be absent before submission.
+  - App Store archive: run `ci_scripts/ci_pre_xcodebuild.sh` without the exact
+    external-beta workflow identity, which writes `.production`.
+  - TestFlight archive: the exact workflow ID
+    `37c9d62c-448d-4f60-8672-496a5c044c34` and name
+    `TestFlight - external beta test` write `.testFlight` automatically.
+  - Verify the script behavior from controlled temporary inputs with
+    `scripts/test_xcode_cloud_distribution_gate.sh` before release work.
 - App Store Connect age-rating declaration is present with no declared medical,
   sexual, violent, gambling, messaging, or advertising content. The project sets
   `ITSAppUsesNonExemptEncryption=false` and has no separate encryption declaration;
@@ -449,8 +451,8 @@ now reports a user-facing state and reconnects only while the scanner remains vi
 Retake filenames now include a UUID suffix to prevent same-second overwrites, and
 upload cancellation now cancels the active task, stops SMB progress, preserves an
 explicit aborted status, and cancels before uploaded-file cleanup. The TestFlight
-override is compile-time gated by `TESTFLIGHT_BUILD`; App Store production
-archives do not contain the control.
+override uses the deterministic Xcode Cloud build channel; App Store production
+actions resolve to `.production`.
 The remaining release work is lifecycle stress, physical-device scanning, and evidence
 from Instruments/MetricKit or an equivalent crash/performance surface. The sequence
 handler change is covered by compilation and the full simulator suite, but a simulator

--- a/docs/APP-STORE-RELEASE-PLAN.md
+++ b/docs/APP-STORE-RELEASE-PLAN.md
@@ -277,6 +277,9 @@ plan: a green compile or unit-test run is not enough to call the app release-rea
     `TestFlight - external beta test` write `.testFlight` automatically.
   - Verify the script behavior from controlled temporary inputs with
     `scripts/test_xcode_cloud_distribution_gate.sh` before release work.
+  - `scripts/release_preflight.sh` verifies the extracted IPA's deterministic
+    Info.plist marker: absent for production and
+    `external-testflight-v1` for TestFlight.
 - App Store Connect age-rating declaration is present with no declared medical,
   sexual, violent, gambling, messaging, or advertising content. The project sets
   `ITSAppUsesNonExemptEncryption=false` and has no separate encryption declaration;
@@ -651,8 +654,7 @@ unzip -l .asc/artifacts/LensBridge-1.58-66-appstore.ipa | grep 'Payload/.app/Pri
 VERIFY_DIR=$(mktemp -d)
 unzip -q .asc/artifacts/LensBridge-1.58-66-appstore.ipa -d "$VERIFY_DIR"
 APP_PATH=$(find "$VERIFY_DIR/Payload" -maxdepth 1 -name '*.app' -print -quit)
-APP_BINARY="$APP_PATH/$(basename "$APP_PATH" .app)"
-if strings "$APP_BINARY" | grep -Fq 'Premium override'; then echo 'Production gate failed'; exit 1; fi
+scripts/verify_build_channel_marker.sh "$APP_PATH" production
 asc builds upload --app 6742799620 --ipa .asc/artifacts/LensBridge-1.58-66-appstore.ipa --platform IOS --wait
 ```
 

--- a/docs/feature-test-coverage.md
+++ b/docs/feature-test-coverage.md
@@ -85,7 +85,7 @@ This note records the app features, the expected behavior, and the tests that co
 
 ## Settings And Discovery
 
-- First setup collects target directory, username, password, optional port, OCR mode, and discovery/manual setup entry points. The premium override is available only in Debug and explicitly flagged TestFlight builds; it is not part of the App Store Release Settings UI.
+- First setup collects target directory, username, password, optional port, OCR mode, and discovery/manual setup entry points. The premium override is available only in Debug and the exact Xcode Cloud external-beta build channel; it is not part of the App Store Release Settings UI.
 - Manual setup collects server IP, share, target directory, optional port, username, and password.
 - Save persists `ServerSettings` and the password.
 - Reset clears fields and returns to first setup.

--- a/docs/premium-feature.md
+++ b/docs/premium-feature.md
@@ -40,16 +40,20 @@ Apple blocks standalone submission for the first IAP with `STATE_ERROR.FIRST_IAP
 - Failed uploads and duplicate-file prompts do not consume trial uploads.
 - The successful upload count and purchased unlock state are stored in Keychain so uninstall/reinstall does not reset the trial.
 - The premium override is stored in UserDefaults only for local/TestFlight
-  validation. Debug builds enable it immediately. A TestFlight candidate is
-  built explicitly with the `TESTFLIGHT_BUILD` Swift compilation condition,
-  which includes the toggle in the Release Settings UI. App Store archives do
-  not set that condition, so the toggle and its implementation are absent from
-  the submitted production binary.
+  validation. Debug builds enable it immediately. Release builds are production
+  safe by default. Before each Xcode Cloud action,
+  `ci_scripts/ci_pre_xcodebuild.sh` writes the channel into the existing
+  `PremiumAccess.swift` source. Only workflow ID
+  `37c9d62c-448d-4f60-8672-496a5c044c34` named
+  `TestFlight - external beta test` writes `.testFlight`; missing or mismatched
+  identity writes `.production` and therefore fails closed. The script's three
+  controlled-input cases can be run with
+  `scripts/test_xcode_cloud_distribution_gate.sh`.
 
 ## Code Map
 
 - `PremiumAccess.swift`: trial state, Keychain persistence, and the
-  compile-time TestFlight-only premium override policy.
+  deterministic build-channel premium override policy.
 - `StoreKitPurchaseManager.swift`: StoreKit 2 product lookup, purchase, automatic entitlement refresh, and user-initiated restore. Restore calls `AppStore.sync()` and then verifies the current Full App Unlock entitlement.
 - `FullAppUnlockView.swift`: paywall screen with price, one-time unlock, and an always-visible Restore Purchases action with result feedback.
 - `UploadView.swift`: blocks upload when trial is exhausted and records each successful upload.

--- a/docs/premium-feature.md
+++ b/docs/premium-feature.md
@@ -48,7 +48,10 @@ Apple blocks standalone submission for the first IAP with `STATE_ERROR.FIRST_IAP
   `TestFlight - external beta test` writes `.testFlight`; missing or mismatched
   identity writes `.production` and therefore fails closed. The script's three
   controlled-input cases can be run with
-  `scripts/test_xcode_cloud_distribution_gate.sh`.
+  `scripts/test_xcode_cloud_distribution_gate.sh`. The exact beta workflow also
+  writes `LensBridgeBuildChannelMarker=external-testflight-v1` to the built app
+  Info.plist; production actions remove that key. Release preflight verifies
+  this artifact marker with `scripts/verify_build_channel_marker.sh`.
 
 ## Code Map
 

--- a/scripts/fixtures/BuildChannelMarkerProductionInfo.plist
+++ b/scripts/fixtures/BuildChannelMarkerProductionInfo.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDisplayName</key>
+    <string>LensBridge</string>
+</dict>
+</plist>

--- a/scripts/fixtures/BuildChannelMarkerTestFlightInfo.plist
+++ b/scripts/fixtures/BuildChannelMarkerTestFlightInfo.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDisplayName</key>
+    <string>LensBridge</string>
+    <key>LensBridgeBuildChannelMarker</key>
+    <string>external-testflight-v1</string>
+</dict>
+</plist>

--- a/scripts/fixtures/BuildDistributionChannelFixture.swift
+++ b/scripts/fixtures/BuildDistributionChannelFixture.swift
@@ -1,0 +1,10 @@
+enum AppBuildChannel: String {
+    case production
+    case testFlight
+}
+
+enum BuildDistributionChannel {
+    static let current: AppBuildChannel = .production
+}
+
+print(BuildDistributionChannel.current.rawValue)

--- a/scripts/release_preflight.sh
+++ b/scripts/release_preflight.sh
@@ -74,10 +74,9 @@ check_ipa() {
     local ipa="$2"
     local expected_marketing_version="$3"
     local expected_build="$4"
-    local expected_premium_string="$5"
+    local expected_build_channel="$5"
     local extraction_dir
     local app
-    local binary
     local display_name
     local short_version
     local build_number
@@ -97,7 +96,6 @@ check_ipa() {
         return
     fi
 
-    binary="$app/$(basename "$app" .app)"
     display_name="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleDisplayName' "$app/Info.plist")"
     short_version="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$app/Info.plist")"
     build_number="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$app/Info.plist")"
@@ -124,25 +122,17 @@ check_ipa() {
         fail "$label strict code signature"
     fi
 
-    if [[ "$expected_premium_string" == "present" ]]; then
-        if strings "$binary" | rg -q 'Premium override'; then
-            pass "$label contains TestFlight Premium override"
-        else
-            fail "$label contains TestFlight Premium override"
-        fi
+    if "$repo_root/scripts/verify_build_channel_marker.sh" "$app" "$expected_build_channel"; then
+        pass "$label has expected $expected_build_channel build-channel marker"
     else
-        if strings "$binary" | rg -q 'Premium override'; then
-            fail "$label excludes production Premium override"
-        else
-            pass "$label excludes production Premium override"
-        fi
+        fail "$label has expected $expected_build_channel build-channel marker"
     fi
 
     rm -rf "$extraction_dir"
 }
 
-check_ipa "production" "$production_ipa" "$marketing_version" "$production_build_number" "absent"
-check_ipa "TestFlight" "$testflight_ipa" "$testflight_marketing_version" "$testflight_build_number" "present"
+check_ipa "production" "$production_ipa" "$marketing_version" "$production_build_number" "production"
+check_ipa "TestFlight" "$testflight_ipa" "$testflight_marketing_version" "$testflight_build_number" "testFlight"
 
 if [[ "$skip_asc" == "1" ]]; then
     note "ASC checks skipped because SKIP_ASC=1"

--- a/scripts/test_release_preflight_build_channel_marker.sh
+++ b/scripts/test_release_preflight_build_channel_marker.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="$repo_root/scripts/verify_build_channel_marker.sh"
+fixtures="$repo_root/scripts/fixtures"
+temp_dir="$(mktemp -d "${TMPDIR:-/tmp}/lensbridge-preflight-marker.XXXXXX")"
+trap 'rm -rf "$temp_dir"' EXIT
+
+production_app="$temp_dir/Production.app"
+testflight_app="$temp_dir/TestFlight.app"
+mkdir -p "$production_app" "$testflight_app"
+cp "$fixtures/BuildChannelMarkerProductionInfo.plist" "$production_app/Info.plist"
+cp "$fixtures/BuildChannelMarkerTestFlightInfo.plist" "$testflight_app/Info.plist"
+
+"$verifier" "$production_app" production
+"$verifier" "$testflight_app" testFlight
+
+if "$verifier" "$production_app" testFlight >/dev/null 2>&1; then
+    printf 'Production artifact unexpectedly passed TestFlight marker verification.\n' >&2
+    exit 1
+fi
+
+if "$verifier" "$testflight_app" production >/dev/null 2>&1; then
+    printf 'TestFlight artifact unexpectedly passed production marker verification.\n' >&2
+    exit 1
+fi
+
+printf 'Release preflight build-channel marker behavior passed.\n'

--- a/scripts/test_xcode_cloud_distribution_gate.sh
+++ b/scripts/test_xcode_cloud_distribution_gate.sh
@@ -4,7 +4,9 @@ set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 gate_script="$repo_root/ci_scripts/ci_pre_xcodebuild.sh"
+marker_verifier="$repo_root/scripts/verify_build_channel_marker.sh"
 fixture="$repo_root/scripts/fixtures/BuildDistributionChannelFixture.swift"
+info_plist_fixture="$repo_root/scripts/fixtures/BuildChannelMarkerProductionInfo.plist"
 temp_dir="$(mktemp -d "${TMPDIR:-/tmp}/lensbridge-build-channel.XXXXXX")"
 trap 'rm -rf "$temp_dir"' EXIT
 
@@ -13,13 +15,17 @@ run_case() {
     local workflow_id="$2"
     local workflow_name="$3"
     local source_file="$temp_dir/BuildDistributionChannel.swift"
+    local info_plist="$temp_dir/Info.plist"
     local actual_channel
 
     cp "$fixture" "$source_file"
+    cp "$info_plist_fixture" "$info_plist"
     CI_WORKFLOW_ID="$workflow_id" \
     CI_WORKFLOW="$workflow_name" \
     BUILD_CHANNEL_SOURCE_FILE="$source_file" \
+    BUILD_CHANNEL_INFO_PLIST="$info_plist" \
     "$gate_script"
+    "$marker_verifier" "$temp_dir" "$expected_channel"
     actual_channel="$(swift "$source_file")"
 
     if [[ "$actual_channel" != "$expected_channel" ]]; then
@@ -34,8 +40,10 @@ run_case production '37c9d62c-448d-4f60-8672-496a5c044c34' 'TestFlight - renamed
 
 run_malformed_case() {
     local source_file="$temp_dir/MalformedBuildDistributionChannel.swift"
+    local info_plist="$temp_dir/MalformedInfo.plist"
 
     cp "$fixture" "$source_file"
+    cp "$info_plist_fixture" "$info_plist"
     /usr/bin/sed -i '' \
         's/static let current: AppBuildChannel = \.production/static let selected: AppBuildChannel = .production/' \
         "$source_file"
@@ -43,6 +51,7 @@ run_malformed_case() {
     if CI_WORKFLOW_ID='37c9d62c-448d-4f60-8672-496a5c044c34' \
         CI_WORKFLOW='TestFlight - external beta test' \
         BUILD_CHANNEL_SOURCE_FILE="$source_file" \
+        BUILD_CHANNEL_INFO_PLIST="$info_plist" \
         "$gate_script" >/dev/null 2>&1; then
         printf 'Malformed build-channel source unexpectedly succeeded.\n' >&2
         exit 1

--- a/scripts/test_xcode_cloud_distribution_gate.sh
+++ b/scripts/test_xcode_cloud_distribution_gate.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+gate_script="$repo_root/ci_scripts/ci_pre_xcodebuild.sh"
+fixture="$repo_root/scripts/fixtures/BuildDistributionChannelFixture.swift"
+temp_dir="$(mktemp -d "${TMPDIR:-/tmp}/lensbridge-build-channel.XXXXXX")"
+trap 'rm -rf "$temp_dir"' EXIT
+
+run_case() {
+    local expected_channel="$1"
+    local workflow_id="$2"
+    local workflow_name="$3"
+    local source_file="$temp_dir/BuildDistributionChannel.swift"
+    local actual_channel
+
+    cp "$fixture" "$source_file"
+    CI_WORKFLOW_ID="$workflow_id" \
+    CI_WORKFLOW="$workflow_name" \
+    BUILD_CHANNEL_SOURCE_FILE="$source_file" \
+    "$gate_script"
+    actual_channel="$(swift "$source_file")"
+
+    if [[ "$actual_channel" != "$expected_channel" ]]; then
+        printf 'Expected %s channel, got %s.\n' "$expected_channel" "$actual_channel" >&2
+        exit 1
+    fi
+}
+
+run_case production '' ''
+run_case testFlight '37c9d62c-448d-4f60-8672-496a5c044c34' 'TestFlight - external beta test'
+run_case production '37c9d62c-448d-4f60-8672-496a5c044c34' 'TestFlight - renamed workflow'
+
+printf 'Xcode Cloud distribution gate behavior passed.\n'

--- a/scripts/test_xcode_cloud_distribution_gate.sh
+++ b/scripts/test_xcode_cloud_distribution_gate.sh
@@ -32,4 +32,23 @@ run_case production '' ''
 run_case testFlight '37c9d62c-448d-4f60-8672-496a5c044c34' 'TestFlight - external beta test'
 run_case production '37c9d62c-448d-4f60-8672-496a5c044c34' 'TestFlight - renamed workflow'
 
+run_malformed_case() {
+    local source_file="$temp_dir/MalformedBuildDistributionChannel.swift"
+
+    cp "$fixture" "$source_file"
+    /usr/bin/sed -i '' \
+        's/static let current: AppBuildChannel = \.production/static let selected: AppBuildChannel = .production/' \
+        "$source_file"
+
+    if CI_WORKFLOW_ID='37c9d62c-448d-4f60-8672-496a5c044c34' \
+        CI_WORKFLOW='TestFlight - external beta test' \
+        BUILD_CHANNEL_SOURCE_FILE="$source_file" \
+        "$gate_script" >/dev/null 2>&1; then
+        printf 'Malformed build-channel source unexpectedly succeeded.\n' >&2
+        exit 1
+    fi
+}
+
+run_malformed_case
+
 printf 'Xcode Cloud distribution gate behavior passed.\n'

--- a/scripts/verify_build_channel_marker.sh
+++ b/scripts/verify_build_channel_marker.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ "$#" != "2" ]]; then
+    printf 'Usage: %s <app-bundle> <production|testFlight>\n' "$0" >&2
+    exit 2
+fi
+
+app_bundle="$1"
+expected_channel="$2"
+info_plist="$app_bundle/Info.plist"
+marker_key='LensBridgeBuildChannelMarker'
+testflight_marker='external-testflight-v1'
+
+if [[ ! -f "$info_plist" ]]; then
+    printf 'Build-channel marker verification requires an app Info.plist.\n' >&2
+    exit 1
+fi
+
+case "$expected_channel" in
+    production)
+        if /usr/libexec/PlistBuddy -c "Print :$marker_key" "$info_plist" >/dev/null 2>&1; then
+            printf 'Production artifact contains a build-channel marker.\n' >&2
+            exit 1
+        fi
+        ;;
+    testFlight)
+        marker_value="$(/usr/libexec/PlistBuddy -c "Print :$marker_key" "$info_plist" 2>/dev/null || true)"
+        if [[ "$marker_value" != "$testflight_marker" ]]; then
+            printf 'TestFlight artifact is missing the expected build-channel marker.\n' >&2
+            exit 1
+        fi
+        ;;
+    *)
+        printf 'Build-channel marker verification requires production or testFlight.\n' >&2
+        exit 2
+        ;;
+esac


### PR DESCRIPTION
## What changed

- Replaced the fallible `AppTransaction.shared` TestFlight detector with a deterministic, production-default build channel.
- Added an Xcode Cloud pre-build gate that enables the beta channel only for the exact external TestFlight workflow ID and name.
- Added fail-closed source-drift validation and a stable `Info.plist` artifact marker.
- Updated release preflight checks and documentation to verify production and TestFlight artifacts correctly.

## Why

Build 76 could hide the Full App Unlock toggle for individual TestFlight testers when StoreKit app-transaction lookup failed or resolved unexpectedly. Toggle availability must depend on the build workflow, not a device/account-specific StoreKit lookup.

## Validation

- Red-to-green unit and script regression tests.
- Full clean Release unit suite: 0 errors, 0 warnings.
- Production Release build: marker absent.
- Exact external-TestFlight Release build: `external-testflight-v1` marker present.
- Independent task review and final whole-branch review completed; all Important findings addressed.
- No project-file, bundle ID, signing, entitlement, marketing-version, or checked-in build-number changes.

## Release behavior

The checked-in source remains production-safe. The external Xcode Cloud workflow prepares the beta channel independently for each action. A future official App Store archive must use a production workflow and pass the production marker gate; build 77 will be distributed only through TestFlight.
