### PR TITLE
Handle Xcode Cloud test replay phase

### DIFF
--- a/ci_scripts/ci_pre_xcodebuild.sh
+++ b/ci_scripts/ci_pre_xcodebuild.sh
@@ -10,6 +10,14 @@ expected_workflow_name="TestFlight - external beta test"
 marker_key='LensBridgeBuildChannelMarker'
 testflight_marker='external-testflight-v1'
 
+# Xcode Cloud runs this pre-script again for each test-without-building
+# destination after build-for-testing has already compiled the channel. Those
+# environments do not retain the source checkout, so they must not validate or
+# mutate build inputs.
+if [[ "${CI_XCODEBUILD_ACTION:-}" == 'test-without-building' ]]; then
+    exit 0
+fi
+
 if [[ ! -f "$source_file" ]]; then
     printf 'Build distribution channel source is missing.\n' >&2
     exit 1

--- a/scripts/test_xcode_cloud_distribution_gate.sh
+++ b/scripts/test_xcode_cloud_distribution_gate.sh
@@ -60,4 +60,16 @@ run_malformed_case() {
 
 run_malformed_case
 
+run_test_without_building_case() {
+    local missing_source="$temp_dir/UnavailableBuildDistributionChannel.swift"
+    local missing_info_plist="$temp_dir/UnavailableInfo.plist"
+
+    CI_XCODEBUILD_ACTION='test-without-building' \
+    BUILD_CHANNEL_SOURCE_FILE="$missing_source" \
+    BUILD_CHANNEL_INFO_PLIST="$missing_info_plist" \
+    "$gate_script"
+}
+
+run_test_without_building_case
+
 printf 'Xcode Cloud distribution gate behavior passed.\n'


### PR DESCRIPTION
## What changed

- Skip the distribution-channel source mutation only during Xcode Cloud's `test-without-building` replay phase.
- Add a regression that runs that phase with deliberately unavailable source and plist inputs.

## Root cause

Run 77 completed `build-for-testing`, then Xcode Cloud invoked `ci_pre_xcodebuild.sh` again in each `test-without-building` destination. Those environments contain the compiled test products but no source checkout, so the script failed with `Build distribution channel source is missing.`

## Safety

Every build-producing action still validates and writes the exact workflow-gated channel and marker. The skip applies only after the products have already been compiled.

## Validation

- Reproduced the Cloud failure with a red missing-input replay test.
- Distribution gate and release-marker suites pass.
- Shell syntax and diff checks pass.
- Independent scoped review found no new breakage.
